### PR TITLE
Jobdata transformers (WIP)

### DIFF
--- a/classes/Pheanstalk/Pheanstalk.php
+++ b/classes/Pheanstalk/Pheanstalk.php
@@ -58,6 +58,22 @@ class Pheanstalk_Pheanstalk implements Pheanstalk_PheanstalkInterface
         return $this;
     }
 
+    /**
+     * Instead of repeating the check in all the necessary methods, have it isolated
+     * in a single method called every time a job is returned.
+     *
+     * @param  string
+     * @return string
+     */
+    private function applyInverseTransform($jobdata)
+    {
+        if(false === is_null($this->_transformer)) {
+            return $this->_transformer->inverseTransform($jobdata);
+        }
+
+        return $jobdata;
+    }
+
     // ----------------------------------------
 
     /**
@@ -165,7 +181,7 @@ class Pheanstalk_Pheanstalk implements Pheanstalk_PheanstalkInterface
             new Pheanstalk_Command_PeekCommand($jobId)
         );
 
-        return new Pheanstalk_Job($response['id'], $response['jobdata']);
+        return new Pheanstalk_Job($response['id'], $this->applyInverseTransform($response['jobdata']));
     }
 
     /**
@@ -181,7 +197,7 @@ class Pheanstalk_Pheanstalk implements Pheanstalk_PheanstalkInterface
             new Pheanstalk_Command_PeekCommand(Pheanstalk_Command_PeekCommand::TYPE_READY)
         );
 
-        return new Pheanstalk_Job($response['id'], $response['jobdata']);
+        return new Pheanstalk_Job($response['id'], $this->applyInverseTransform($response['jobdata']));
     }
 
     /**
@@ -197,7 +213,7 @@ class Pheanstalk_Pheanstalk implements Pheanstalk_PheanstalkInterface
             new Pheanstalk_Command_PeekCommand(Pheanstalk_Command_PeekCommand::TYPE_DELAYED)
         );
 
-        return new Pheanstalk_Job($response['id'], $response['jobdata']);
+        return new Pheanstalk_Job($response['id'], $this->applyInverseTransform($response['jobdata']));
     }
 
     /**
@@ -213,7 +229,7 @@ class Pheanstalk_Pheanstalk implements Pheanstalk_PheanstalkInterface
             new Pheanstalk_Command_PeekCommand(Pheanstalk_Command_PeekCommand::TYPE_BURIED)
         );
 
-        return new Pheanstalk_Job($response['id'], $response['jobdata']);
+        return new Pheanstalk_Job($response['id'], $this->applyInverseTransform($response['jobdata']));
     }
 
     /**
@@ -226,6 +242,11 @@ class Pheanstalk_Pheanstalk implements Pheanstalk_PheanstalkInterface
         $ttr = Pheanstalk_PheanstalkInterface::DEFAULT_TTR
     )
     {
+        if(false === is_null($this->_transformer))
+        {
+            $data = $this->_transformer->transform($data);
+        }
+
         $response = $this->_dispatch(
             new Pheanstalk_Command_PutCommand($data, $priority, $delay, $ttr)
         );
@@ -282,7 +303,7 @@ class Pheanstalk_Pheanstalk implements Pheanstalk_PheanstalkInterface
         if (in_array($response->getResponseName(), $falseResponses)) {
             return false;
         } else {
-            return new Pheanstalk_Job($response['id'], $response['jobdata']);
+            return new Pheanstalk_Job($response['id'], $this->applyInverseTransform($response['jobdata']));
         }
     }
 

--- a/classes/Pheanstalk/Pheanstalk.php
+++ b/classes/Pheanstalk/Pheanstalk.php
@@ -18,6 +18,7 @@ class Pheanstalk_Pheanstalk implements Pheanstalk_PheanstalkInterface
     private $_connection;
     private $_using = Pheanstalk_PheanstalkInterface::DEFAULT_TUBE;
     private $_watching = array(Pheanstalk_PheanstalkInterface::DEFAULT_TUBE => true);
+    private $_transformer = null;
 
     /**
      * @param string $host
@@ -44,6 +45,17 @@ class Pheanstalk_Pheanstalk implements Pheanstalk_PheanstalkInterface
     public function getConnection()
     {
         return $this->_connection;
+    }
+
+    // ----------------------------------------
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setTransformer(Pheanstalk_TransformerInterface $transformer)
+    {
+        $this->_transformer = $transformer;
+        return $this;
     }
 
     // ----------------------------------------

--- a/classes/Pheanstalk/PheanstalkInterface.php
+++ b/classes/Pheanstalk/PheanstalkInterface.php
@@ -23,6 +23,16 @@ interface Pheanstalk_PheanstalkInterface {
     // ----------------------------------------
 
     /**
+     * Transformer to use when data is stored and retrieved
+     *
+     * @param Pheanstalk_TransformerInterface $transformer
+     * @chainable
+     */
+    public function setTransformer(Pheanstalk_TransformerInterface $transformer);
+
+    // ----------------------------------------
+
+    /**
      * Puts a job into a 'buried' state, revived only by 'kick' command.
      *
      * @param Pheanstalk_Job $job

--- a/classes/Pheanstalk/Transformer/JSONTransformer.php
+++ b/classes/Pheanstalk/Transformer/JSONTransformer.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Use PHP's json_encode/json_decode on the job data
+ *
+ * @author Marius Ghita
+ * @package Pheanstalk
+ * @licence http://www.opensource.org/licenses/mit-license.php
+ */
+class Pheanstalk_JSONTransformer implements Pheanstalk_TransformerInterface
+{
+
+    protected $encode_options;
+    protected $decode_assoc;
+    protected $decode_depth;
+    protected $decode_options;
+
+    /**
+     * Provide json encoding/decoding specific parameters
+     *
+     * @see json_encode
+     * @see json_decode
+     * @param int $encode_options
+     * @param bool $decode_assoc
+     */
+    public function __construct($encode_options = 0, $decode_assoc = false, $decode_depth = 512, $decode_options = 0)
+    {
+        $this->encode_options = $encode_options;
+        $this->decode_assoc   = $decode_assoc;
+        $this->decode_depth   = $decode_depth;
+        $this->decode_options = $decode_options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($jobdata)
+    {
+        return json_encode($jobdata, $this->encode_options);
+    }
+
+
+    /**
+     * {@inheritdoc}
+     * @todo check for errors in decoding and report appropiately. With a typed exception?
+     */
+    public function inverseTransform($jobdata)
+    {
+        return json_decode($jobdata, $this->decode_assoc, $this->decode_depth, $this->decode_options);
+    }
+}

--- a/classes/Pheanstalk/Transformer/PHPSerializationTransformer.php
+++ b/classes/Pheanstalk/Transformer/PHPSerializationTransformer.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Use PHP's serialize/unserialize on the job data
+ *
+ * @author Marius Ghita
+ * @package Pheanstalk
+ * @licence http://www.opensource.org/licenses/mit-license.php
+ */
+class Pheanstalk_PHPSerializationTransformer implements Pheanstalk_TransformerInterface
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function transform($jobdata)
+    {
+        return serialize($jobdata);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function inverseTransform($jobdata)
+    {
+        return unserialize($jobdata);
+    }
+}

--- a/classes/Pheanstalk/TransformerInterface.php
+++ b/classes/Pheanstalk/TransformerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Interface by which job data transformations can be provided. By default messages
+ * are strings, but with this interface a way to transform/serialize that data upon
+ * storage and retrieval can be specified.
+ *
+ * @author Marius Ghita
+ * @package Pheanstalk
+ * @licence http://www.opensource.org/licenses/mit-license.php
+ */
+interface Pheanstalk_TransformerInterface
+{
+    /**
+     * @param  string $jobdata
+     * @return string
+     */
+    public function transform($jobdata);
+
+    /**
+     * @param  string $jobdata
+     * @return string
+     */
+    public function inverseTransform($jobdata);
+}


### PR DESCRIPTION
There is this emerging pattern that shows up every time I use Pheanstalk, where I send over composite data and have to serialize it in PHP or JSON, but manually doing it all the time.

Till now I had my custom extension to the original Pheanstalk class to achieve this, but I'd consider it may be a fine addition to the core.

Attached are a couple of lines changed/added to illustrate the point, and if it's a desired feature for you as well, I'll continue to add tests and what else may be required to have a good PR :)

- [ ] Add phpunit tests for transformers