### PR TITLE
Add persistent connection support

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -37,13 +37,14 @@ class Connection
     private $_hostname;
     private $_port;
     private $_connectTimeout;
+    private $_connectPersistent;
 
     /**
      * @param string $hostname
      * @param int    $port
      * @param float  $connectTimeout
      */
-    public function __construct($hostname, $port, $connectTimeout = null)
+    public function __construct($hostname, $port, $connectTimeout = null, $connectPersistent = false)
     {
         if (is_null($connectTimeout) || !is_numeric($connectTimeout)) {
             $connectTimeout = self::DEFAULT_CONNECT_TIMEOUT;
@@ -52,6 +53,7 @@ class Connection
         $this->_hostname = $hostname;
         $this->_port = $port;
         $this->_connectTimeout = $connectTimeout;
+        $this->_connectPersistent = $connectPersistent;
     }
 
     /**
@@ -165,7 +167,8 @@ class Connection
             $this->_socket = new NativeSocket(
                 $this->_hostname,
                 $this->_port,
-                $this->_connectTimeout
+                $this->_connectTimeout,
+                $this->_connectPersistent
             );
         }
 

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -26,9 +26,9 @@ class Pheanstalk implements PheanstalkInterface
      * @param int    $port
      * @param int    $connectTimeout
      */
-    public function __construct($host, $port = PheanstalkInterface::DEFAULT_PORT, $connectTimeout = null)
+    public function __construct($host, $port = PheanstalkInterface::DEFAULT_PORT, $connectTimeout = null, $connectPersistent = false)
     {
-        $this->setConnection(new Connection($host, $port, $connectTimeout));
+        $this->setConnection(new Connection($host, $port, $connectTimeout, $connectPersistent));
     }
 
     /**

--- a/src/Socket/NativeSocket.php
+++ b/src/Socket/NativeSocket.php
@@ -31,10 +31,10 @@ class NativeSocket implements Socket
      * @param int    $port
      * @param int    $connectTimeout
      */
-    public function __construct($host, $port, $connectTimeout)
+    public function __construct($host, $port, $connectTimeout, $connectPersistent)
     {
         $this->_socket = $this->_wrapper()
-            ->fsockopen($host, $port, $errno, $errstr, $connectTimeout);
+            ->fsockopen($host, $port, $errno, $errstr, $connectTimeout, $connectPersistent);
 
         if (!$this->_socket) {
             throw new Exception\ConnectionException($errno, $errstr . " (connecting to $host:$port)");

--- a/src/Socket/StreamFunctions.php
+++ b/src/Socket/StreamFunctions.php
@@ -68,11 +68,13 @@ class StreamFunctions
         return fread($handle, $length);
     }
 
-    public function fsockopen($hostname, $port = -1, &$errno = null, &$errstr = null, $timeout = null)
+    public function fsockopen($hostname, $port = -1, &$errno = null, &$errstr = null, $timeout = null, $persistent = false)
     {
-        // Warnings (e.g. connection refused) suppressed;
-        // return value, $errno and $errstr should be checked instead.
-        return @fsockopen($hostname, $port, $errno, $errstr, $timeout);
+        if ($persistent) {
+            return @pfsockopen($hostname, $port, $errno, $errstr, $timeout);
+        } else {
+            return @fsockopen($hostname, $port, $errno, $errstr, $timeout);
+        }
     }
 
     public function fwrite($handle, $string, $length = null)

--- a/tests/Pheanstalk/NativeSocketTest.php
+++ b/tests/Pheanstalk/NativeSocketTest.php
@@ -17,6 +17,7 @@ class NativeSocketTest extends \PHPUnit_Framework_TestCase
     const DEFAULT_HOST = 'localhost';
     const DEFAULT_PORT = 11300;
     const DEFAULT_CONNECTION_TIMEOUT = 0;
+    const DEFAULT_PERSISTENT_CONNECTION = false;
 
     private $_streamFunctions;
 
@@ -55,7 +56,8 @@ class NativeSocketTest extends \PHPUnit_Framework_TestCase
         $socket = new NativeSocket(
             self::DEFAULT_HOST,
             self::DEFAULT_HOST,
-            self::DEFAULT_CONNECTION_TIMEOUT
+            self::DEFAULT_CONNECTION_TIMEOUT,
+            self::DEFAULT_PERSISTENT_CONNECTION
         );
         $socket->write('data');
     }
@@ -70,7 +72,7 @@ class NativeSocketTest extends \PHPUnit_Framework_TestCase
              ->method('fread')
              ->will($this->returnValue(false));
 
-        $socket = new NativeSocket(self::DEFAULT_HOST, self::DEFAULT_HOST, self::DEFAULT_CONNECTION_TIMEOUT);
+        $socket = new NativeSocket(self::DEFAULT_HOST, self::DEFAULT_HOST, self::DEFAULT_CONNECTION_TIMEOUT, self::DEFAULT_PERSISTENT_CONNECTION);
         $socket->read(1);
     }
 }


### PR DESCRIPTION
It uses pfsocketopen instead of fsocketopen. Did some initial testing (with hundreds of thousands of jobs and lots of clients) and socket reuse worked great.