### PR TITLE
allow changing socket timeout, prevent loops on failing getLine calls

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -37,13 +37,14 @@ class Connection
     private $_hostname;
     private $_port;
     private $_connectTimeout;
+    private $_socketTimeout;
 
     /**
      * @param string $hostname
      * @param int    $port
      * @param float  $connectTimeout
      */
-    public function __construct($hostname, $port, $connectTimeout = null)
+    public function __construct($hostname, $port, $connectTimeout = null, $socketTimeout = null)
     {
         if (is_null($connectTimeout) || !is_numeric($connectTimeout)) {
             $connectTimeout = self::DEFAULT_CONNECT_TIMEOUT;
@@ -52,6 +53,7 @@ class Connection
         $this->_hostname = $hostname;
         $this->_port = $port;
         $this->_connectTimeout = $connectTimeout;
+        $this->_socketTimeout = $socketTimeout;
     }
 
     /**
@@ -165,7 +167,8 @@ class Connection
             $this->_socket = new NativeSocket(
                 $this->_hostname,
                 $this->_port,
-                $this->_connectTimeout
+                $this->_connectTimeout,
+                $this->_socketTimeout
             );
         }
 

--- a/src/Socket/StreamFunctions.php
+++ b/src/Socket/StreamFunctions.php
@@ -63,6 +63,11 @@ class StreamFunctions
         return fopen($filename, $mode);
     }
 
+    public function fclose($handle)
+    {
+        return fclose($handle);
+    }
+
     public function fread($handle, $length)
     {
         return fread($handle, $length);

--- a/tests/Pheanstalk/NativeSocketTest.php
+++ b/tests/Pheanstalk/NativeSocketTest.php
@@ -17,6 +17,7 @@ class NativeSocketTest extends \PHPUnit_Framework_TestCase
     const DEFAULT_HOST = 'localhost';
     const DEFAULT_PORT = 11300;
     const DEFAULT_CONNECTION_TIMEOUT = 0;
+    const DEFAULT_SOCKET_TIMEOUT = 0;
 
     private $_streamFunctions;
 
@@ -55,7 +56,8 @@ class NativeSocketTest extends \PHPUnit_Framework_TestCase
         $socket = new NativeSocket(
             self::DEFAULT_HOST,
             self::DEFAULT_HOST,
-            self::DEFAULT_CONNECTION_TIMEOUT
+            self::DEFAULT_CONNECTION_TIMEOUT,
+            self::DEFAULT_SOCKET_TIMEOUT
         );
         $socket->write('data');
     }
@@ -70,7 +72,31 @@ class NativeSocketTest extends \PHPUnit_Framework_TestCase
              ->method('fread')
              ->will($this->returnValue(false));
 
-        $socket = new NativeSocket(self::DEFAULT_HOST, self::DEFAULT_HOST, self::DEFAULT_CONNECTION_TIMEOUT);
+        $socket = new NativeSocket(
+            self::DEFAULT_HOST,
+            self::DEFAULT_HOST,
+            self::DEFAULT_CONNECTION_TIMEOUT,
+            self::DEFAULT_SOCKET_TIMEOUT
+        );
         $socket->read(1);
+    }
+
+    /**
+     * @expectedException \Pheanstalk\Exception\SocketException
+     * @expectedExceptionMessage fgets() returned false
+     */
+    public function testGetLine()
+    {
+        $this->_streamFunctions->expects($this->any())
+             ->method('fgets')
+             ->will($this->returnValue(false));
+
+        $socket = new NativeSocket(
+            self::DEFAULT_HOST,
+            self::DEFAULT_HOST,
+            self::DEFAULT_CONNECTION_TIMEOUT,
+            self::DEFAULT_SOCKET_TIMEOUT
+        );
+        $socket->getLine();
     }
 }


### PR DESCRIPTION
In a scenario where an existing connection to beanstalk is timing out, the code would loop indefinitely during a getLine call. This makes the getLine method obey the socket timeout (as the read and write methods already do). This change also allows the socket timeout to be configurable when instantiating the Pheanstalk instance. This also fixes #13.

The exception handler in Pheanstalk#_dispatch will still attempt to perform one reconnection in the event of a failure before giving up completely.
