### PR TITLE
Docker for phpunit tests

### DIFF
--- a/tests/Dockerfile.test
+++ b/tests/Dockerfile.test
@@ -1,0 +1,21 @@
+# Builds a Docker image for running pheanstalk tests.
+# Build should be initiated from main pheanstalk directory:
+#     docker build --file=tests/Dockerfile.test --tag=pheanstalk-test .
+# Run the tests against the build-in codebase:
+#     docker run pheanstalk-test
+# Run the tests against a mounted codebase:
+#     docker run --volume=/your/pheanstalk:/pheanstalk pheanstalk-test
+
+FROM php:5.6-cli
+
+# Build image; optimize for Docker build cache
+ADD tests/docker-builder /docker-builder
+RUN /docker-builder
+
+# Initialize app; little chance of Docker build cache.
+ADD . /pheanstalk
+RUN composer --working-dir=/pheanstalk install
+
+# Image configuration
+WORKDIR /pheanstalk
+CMD ["/pheanstalk/tests/docker-run-tests"]

--- a/tests/docker-builder
+++ b/tests/docker-builder
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -eou pipefail
+
+main() {
+  apt-setup
+  install-beanstalkd
+  install-php-zipfile-support
+  install-composer
+  apt-teardown
+}
+
+apt-setup() {
+  apt-get update
+}
+
+apt-teardown() {
+  # don't commit apt index to Docker layer
+  rm -r /var/lib/apt/lists/*
+}
+
+install-beanstalkd() {
+  apt-get -y install beanstalkd
+}
+
+install-php-zipfile-support() {
+  # PHP zip file support
+  apt-get -y install zlib1g-dev
+  docker-php-ext-install zip
+}
+
+install-composer() {
+  curl --silent --show-error https://getcomposer.org/installer |
+    php -- --install-dir=/usr/local/bin --filename=composer
+}
+
+main

--- a/tests/docker-run-tests
+++ b/tests/docker-run-tests
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eou pipefail
+
+beanstalkd &
+sleep 0.1
+
+/pheanstalk/vendor/bin/phpunit


### PR DESCRIPTION
Provides a `tests/Dockerfile.test` which can be built locally to run tests:

``` sh
docker build --file=tests/Dockerfile.test --tag=pheanstalk-test .
docker run pheanstalk-test
```

The `docker build …` step builds the current codebase on disk into the image, and installs composer dependencies (phpunit etc) each time. This is simple but slow. Each code change requires a image rebuild to test it.

Instead, if your pheanstalk codebase directory is available on your docker host (e.g. you're running linux directly, or using some network filesystem or synchronization), you could just build the `pheanstalk-test` image once and then:

``` sh
# composer install only when dependencies change
docker run --volume=/your/local/pheanstalk:/pheanstalk composer install

# run tests without waiting for long build processes
docker run --volume=/your/local/pheanstalk:/pheanstalk
```
