### PR TITLE
Add $pheanstalk->getConnection()->disconnect() method.

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -67,6 +67,21 @@ class Connection
         return $this;
     }
 
+    public function hasSocket()
+    {
+        return isset($this->_socket);
+    }
+
+    /**
+     * Disconnect the socket.
+     * Subsequent socket operations will create a new connection.
+     */
+    public function disconnect()
+    {
+        $this->_getSocket()->disconnect();
+        $this->_socket = null;
+    }
+
     /**
      * @param  object                    $command Command
      * @return object                    Response

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -33,4 +33,9 @@ interface Socket
      * @param int
      */
     public function getLine($length = null);
+
+    /**
+     * Disconnect the socket; subsequent usage of the socket will fail.
+     */
+    public function disconnect();
 }

--- a/src/Socket/NativeSocket.php
+++ b/src/Socket/NativeSocket.php
@@ -107,6 +107,11 @@ class NativeSocket implements Socket
         return rtrim($data);
     }
 
+    public function disconnect()
+    {
+        $this->_wrapper()->fclose($this->_socket);
+    }
+
     // ----------------------------------------
 
     /**

--- a/src/Socket/StreamFunctions.php
+++ b/src/Socket/StreamFunctions.php
@@ -84,6 +84,11 @@ class StreamFunctions
         }
     }
 
+    public function fclose($handle)
+    {
+        fclose($handle);
+    }
+
     public function stream_set_timeout($stream, $seconds, $microseconds = 0)
     {
         return stream_set_timeout($stream, $seconds, $microseconds);

--- a/tests/Pheanstalk/ConnectionTest.php
+++ b/tests/Pheanstalk/ConnectionTest.php
@@ -77,6 +77,23 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(__METHOD__, $job->getData());
     }
 
+    public function testDisconnect()
+    {
+        $connection = $this->_getConnection();
+
+        // initial connection
+        $connection->dispatchCommand(new Command\StatsCommand());
+        $this->assertTrue($connection->hasSocket());
+
+        // disconnect
+        $connection->disconnect();
+        $this->assertFalse($connection->hasSocket());
+
+        // auto-reconnect
+        $connection->dispatchCommand(new Command\StatsCommand());
+        $this->assertTrue($connection->hasSocket());
+    }
+
     // ----------------------------------------
     // private
 


### PR DESCRIPTION
Adds a `disconnect()` method to `Pheanstalk\Connection` such that `$pheanstalk->getConnection()->disconnect()` disconnects from the beanstalkd server and dereferences `$this->_socket` for garbage collection. Subsequent operations that require the socket will cause a reconnect.

Disconnecting the TCP socket is preferable to sending the unimplemented QUIT command — as far as I know that command only really exists for convenience of interactive human sessions, i.e. `telnet localhost 11300`.

---

* Closes #34
* Resolves #102