### PR TITLE
Add support for changing watchlist using arrays

### DIFF
--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -74,11 +74,13 @@ class Pheanstalk implements PheanstalkInterface
     /**
      * {@inheritdoc}
      */
-    public function ignore($tube)
+    public function ignore($tubes)
     {
-        if (isset($this->_watching[$tube])) {
-            $this->_dispatch(new Command\IgnoreCommand($tube));
-            unset($this->_watching[$tube]);
+        foreach ((array) $tubes as $tube) {
+            if (isset($this->_watching[$tube])) {
+                $this->_dispatch(new Command\IgnoreCommand($tube));
+                unset($this->_watching[$tube]);
+            }
         }
 
         return $this;
@@ -352,11 +354,13 @@ class Pheanstalk implements PheanstalkInterface
     /**
      * {@inheritdoc}
      */
-    public function watch($tube)
+    public function watch($tubes)
     {
-        if (!isset($this->_watching[$tube])) {
-            $this->_dispatch(new Command\WatchCommand($tube));
-            $this->_watching[$tube] = true;
+        foreach ((array) $tubes as $tube) {
+            if (!isset($this->_watching[$tube])) {
+                $this->_dispatch(new Command\WatchCommand($tube));
+                $this->_watching[$tube] = true;
+            }
         }
 
         return $this;
@@ -365,14 +369,12 @@ class Pheanstalk implements PheanstalkInterface
     /**
      * {@inheritdoc}
      */
-    public function watchOnly($tube)
+    public function watchOnly($tubes)
     {
-        $this->watch($tube);
+        $this->watch($tubes);
 
-        $ignoreTubes = array_diff_key($this->_watching, array($tube => true));
-        foreach ($ignoreTubes as $ignoreTube => $true) {
-            $this->ignore($ignoreTube);
-        }
+        $ignoreTubes = array_diff_key($this->_watching, array_fill_keys((array) $tubes, true));
+        $this->ignore(array_keys($ignoreTubes));
 
         return $this;
     }

--- a/src/PheanstalkInterface.php
+++ b/src/PheanstalkInterface.php
@@ -45,16 +45,16 @@ interface PheanstalkInterface
     public function delete($job);
 
     /**
-     * Remove the specified tube from the watchlist.
+     * Remove the specified tubes from the watchlist.
      *
      * Does not execute an IGNORE command if the specified tube is not in the
      * cached watchlist.
      *
-     * @param string $tube
+     * @param string|string[] $tubes
      *
      * @return $this
      */
-    public function ignore($tube);
+    public function ignore($tubes);
 
     /**
      * Kicks buried or delayed jobs into a 'ready' state.
@@ -302,24 +302,24 @@ interface PheanstalkInterface
     public function useTube($tube);
 
     /**
-     * Add the specified tube to the watchlist, to reserve jobs from.
+     * Add the specified tubes to the watchlist, to reserve jobs from.
      *
      * Does not execute a WATCH command if the client is already watching the
      * specified tube.
      *
-     * @param string $tube
+     * @param string|string[] $tubes
      *
      * @return $this
      */
-    public function watch($tube);
+    public function watch($tubes);
 
     /**
-     * Adds the specified tube to the watchlist, to reserve jobs from, and
+     * Adds the specified tubes to the watchlist, to reserve jobs from, and
      * ignores any other tubes remaining on the watchlist.
      *
-     * @param string $tube
+     * @param string|string[] $tubes
      *
      * @return $this
      */
-    public function watchOnly($tube);
+    public function watchOnly($tubes);
 }

--- a/tests/Pheanstalk/FacadeConnectionTest.php
+++ b/tests/Pheanstalk/FacadeConnectionTest.php
@@ -39,20 +39,32 @@ class FacadeConnectionTest extends \PHPUnit_Framework_TestCase
     {
         $pheanstalk = $this->_getFacade();
 
-        $this->assertEquals($pheanstalk->listTubesWatched(), array('default'));
-        $this->assertEquals($pheanstalk->listTubesWatched(true), array('default'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(), array('default'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(true), array('default'));
 
         $pheanstalk->watch('test');
-        $this->assertEquals($pheanstalk->listTubesWatched(), array('default', 'test'));
-        $this->assertEquals($pheanstalk->listTubesWatched(true), array('default', 'test'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(), array('default', 'test'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(true), array('default', 'test'));
 
         $pheanstalk->ignore('default');
-        $this->assertEquals($pheanstalk->listTubesWatched(), array('test'));
-        $this->assertEquals($pheanstalk->listTubesWatched(true), array('test'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(), array('test'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(true), array('test'));
 
         $pheanstalk->watchOnly('default');
-        $this->assertEquals($pheanstalk->listTubesWatched(), array('default'));
-        $this->assertEquals($pheanstalk->listTubesWatched(true), array('default'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(), array('default'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(true), array('default'));
+
+        $pheanstalk->watch(array('test', 'another-test', 'yet-another-test'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(), array('default', 'test', 'another-test', 'yet-another-test'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(true), array('default', 'test', 'another-test', 'yet-another-test'));
+
+        $pheanstalk->ignore(array('another-test', 'yet-another-test'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(), array('default', 'test'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(true), array('default', 'test'));
+
+        $pheanstalk->watchOnly(array('another-test', 'yet-another-test'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(), array('another-test', 'yet-another-test'));
+        $this->_assertTubes($pheanstalk->listTubesWatched(true), array('another-test', 'yet-another-test'));
     }
 
     /**
@@ -63,6 +75,16 @@ class FacadeConnectionTest extends \PHPUnit_Framework_TestCase
         $pheanstalk = $this->_getFacade();
 
         $pheanstalk->ignore('default');
+    }
+
+    /**
+     * @expectedException \Pheanstalk\Exception
+     */
+    public function testWatchEmptyTubeList()
+    {
+        $pheanstalk = $this->_getFacade();
+
+        $pheanstalk->watchOnly(array());
     }
 
     public function testPutReserveAndDeleteData()
@@ -393,6 +415,15 @@ class FacadeConnectionTest extends \PHPUnit_Framework_TestCase
 
     // ----------------------------------------
     // private
+
+    /**
+     * @param string[] $tubes
+     * @param string[] $expected
+     */
+    private function _assertTubes($tubes, $expected)
+    {
+        $this->assertEquals(sort($tubes), sort($expected));
+    }
 
     private function _getFacade()
     {


### PR DESCRIPTION
Methods that modify watchlist accept array of tube names, along with single tube name.
