### PR TITLE
Fix : infinite loop in case of remote beanstalk server goes unreachable network

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -6,7 +6,6 @@ namespace Pheanstalk;
  * A command to be sent to the beanstalkd server, and response processing logic.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 interface Command

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -9,11 +9,9 @@ use Pheanstalk\Response;
  * Common functionality for Command implementations.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-abstract class AbstractCommand
-    implements Command
+abstract class AbstractCommand implements Command
 {
     /* (non-phpdoc)
      * @see Command::hasData()
@@ -70,7 +68,7 @@ abstract class AbstractCommand
      *
      * @return object Response
      */
-    protected function _createResponse($name, $data = array())
+    protected function _createResponse($name, $data = [])
     {
         return new Response\ArrayResponse($name, $data);
     }

--- a/src/Command/BuryCommand.php
+++ b/src/Command/BuryCommand.php
@@ -11,12 +11,9 @@ use Pheanstalk\Response;
  * Puts a job into a 'buried' state, revived only by 'kick' command.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class BuryCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class BuryCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_job;
     private $_priority;

--- a/src/Command/DeleteCommand.php
+++ b/src/Command/DeleteCommand.php
@@ -11,12 +11,9 @@ use Pheanstalk\Response;
  * Permanently deletes an already-reserved job.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class DeleteCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class DeleteCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_job;
 

--- a/src/Command/IgnoreCommand.php
+++ b/src/Command/IgnoreCommand.php
@@ -11,12 +11,9 @@ use Pheanstalk\Response;
  * Removes a tube from the watch list to reserve jobs from.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class IgnoreCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class IgnoreCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_tube;
 
@@ -42,9 +39,9 @@ class IgnoreCommand
     public function parseResponse($responseLine, $responseData)
     {
         if (preg_match('#^WATCHING (\d+)$#', $responseLine, $matches)) {
-            return $this->_createResponse('WATCHING', array(
+            return $this->_createResponse('WATCHING', [
                 'count' => (int) $matches[1],
-            ));
+            ]);
         } elseif ($responseLine == Response::RESPONSE_NOT_IGNORED) {
             throw new Exception\ServerException(
                 $responseLine.': cannot ignore last tube in watchlist'

--- a/src/Command/KickCommand.php
+++ b/src/Command/KickCommand.php
@@ -10,12 +10,9 @@ namespace Pheanstalk\Command;
  * Otherwise, it will kick up to $max delayed jobs.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class KickCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class KickCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_max;
 
@@ -42,8 +39,8 @@ class KickCommand
     {
         list($code, $count) = explode(' ', $responseLine);
 
-        return $this->_createResponse($code, array(
+        return $this->_createResponse($code, [
             'kicked' => (int) $count,
-        ));
+        ]);
     }
 }

--- a/src/Command/KickJobCommand.php
+++ b/src/Command/KickJobCommand.php
@@ -15,12 +15,9 @@ use Pheanstalk\Response;
  * ready queue of the the same tube where it currently belongs.
  *
  * @author  Matthieu Napoli
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class KickJobCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class KickJobCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_job;
 

--- a/src/Command/ListTubeUsedCommand.php
+++ b/src/Command/ListTubeUsedCommand.php
@@ -8,12 +8,9 @@ namespace Pheanstalk\Command;
  * Returns the tube currently being used by the client.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ListTubeUsedCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class ListTubeUsedCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     /* (non-phpdoc)
      * @see Command::getCommandLine()
@@ -28,8 +25,8 @@ class ListTubeUsedCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        return $this->_createResponse('USING', array(
+        return $this->_createResponse('USING', [
             'tube' => preg_replace('#^USING (.+)$#', '$1', $responseLine),
-        ));
+        ]);
     }
 }

--- a/src/Command/ListTubesCommand.php
+++ b/src/Command/ListTubesCommand.php
@@ -10,11 +10,9 @@ use Pheanstalk\YamlResponseParser;
  * List all existing tubes.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ListTubesCommand
-    extends AbstractCommand
+class ListTubesCommand extends AbstractCommand
 {
     /* (non-phpdoc)
      * @see Command::getCommandLine()

--- a/src/Command/ListTubesWatchedCommand.php
+++ b/src/Command/ListTubesWatchedCommand.php
@@ -10,11 +10,9 @@ use Pheanstalk\YamlResponseParser;
  * Lists the tubes on the watchlist.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ListTubesWatchedCommand
-    extends AbstractCommand
+class ListTubesWatchedCommand extends AbstractCommand
 {
     /* (non-phpdoc)
      * @see Command::getCommandLine()

--- a/src/Command/PauseTubeCommand.php
+++ b/src/Command/PauseTubeCommand.php
@@ -11,12 +11,9 @@ use Pheanstalk\Response;
  * Temporarily prevent jobs being reserved from the given tube.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class PauseTubeCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class PauseTubeCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_tube;
     private $_delay;

--- a/src/Command/PeekCommand.php
+++ b/src/Command/PeekCommand.php
@@ -12,23 +12,20 @@ use Pheanstalk\Response;
  * variations. All but the first (peek) operate only on the currently used tube.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class PeekCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class PeekCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     const TYPE_ID = 'id';
     const TYPE_READY = 'ready';
     const TYPE_DELAYED = 'delayed';
     const TYPE_BURIED = 'buried';
 
-    private $_subcommands = array(
+    private $_subcommands = [
         self::TYPE_READY,
         self::TYPE_DELAYED,
         self::TYPE_BURIED,
-    );
+    ];
 
     private $_subcommand;
     private $_jobId;
@@ -83,10 +80,10 @@ class PeekCommand
         } elseif (preg_match('#^FOUND (\d+) \d+$#', $responseLine, $matches)) {
             return $this->_createResponse(
                 Response::RESPONSE_FOUND,
-                array(
+                [
                     'id'      => (int) $matches[1],
                     'jobdata' => $responseData,
-                )
+                ]
             );
         }
     }

--- a/src/Command/PutCommand.php
+++ b/src/Command/PutCommand.php
@@ -12,12 +12,9 @@ use Pheanstalk\Exception;
  * @see UseCommand
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class PutCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class PutCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_data;
     private $_priority;
@@ -88,9 +85,9 @@ class PutCommand
     public function parseResponse($responseLine, $responseData)
     {
         if (preg_match('#^INSERTED (\d+)$#', $responseLine, $matches)) {
-            return $this->_createResponse('INSERTED', array(
+            return $this->_createResponse('INSERTED', [
                 'id' => (int) $matches[1],
-            ));
+            ]);
         } elseif (preg_match('#^BURIED (\d)+$#', $responseLine, $matches)) {
             throw new Exception(sprintf(
                 '%s: server ran out of memory trying to grow the priority queue data structure.',

--- a/src/Command/ReleaseCommand.php
+++ b/src/Command/ReleaseCommand.php
@@ -11,12 +11,9 @@ use Pheanstalk\Response;
  * Releases a reserved job back onto the ready queue.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ReleaseCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class ReleaseCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_job;
     private $_priority;

--- a/src/Command/ReserveCommand.php
+++ b/src/Command/ReserveCommand.php
@@ -10,12 +10,9 @@ use Pheanstalk\Response;
  * Reserves/locks a ready job in a watched tube.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ReserveCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class ReserveCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_timeout;
 
@@ -47,15 +44,15 @@ class ReserveCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        if (in_array($responseLine, array(Response::RESPONSE_DEADLINE_SOON, Response::RESPONSE_TIMED_OUT), true)) {
+        if (in_array($responseLine, [Response::RESPONSE_DEADLINE_SOON, Response::RESPONSE_TIMED_OUT], true)) {
             return $this->_createResponse($responseLine);
         }
 
         list($code, $id) = explode(' ', $responseLine);
 
-        return $this->_createResponse($code, array(
+        return $this->_createResponse($code, [
             'id'      => (int) $id,
             'jobdata' => $responseData,
-        ));
+        ]);
     }
 }

--- a/src/Command/StatsCommand.php
+++ b/src/Command/StatsCommand.php
@@ -10,11 +10,9 @@ use Pheanstalk\YamlResponseParser;
  * Statistical information about the system as a whole.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class StatsCommand
-    extends AbstractCommand
+class StatsCommand extends AbstractCommand
 {
     /* (non-phpdoc)
      * @see Command::getCommandLine()

--- a/src/Command/StatsJobCommand.php
+++ b/src/Command/StatsJobCommand.php
@@ -10,11 +10,9 @@ use Pheanstalk\YamlResponseParser;
  * Gives statistical information about the specified job if it exists.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class StatsJobCommand
-    extends AbstractCommand
+class StatsJobCommand extends AbstractCommand
 {
     private $_jobId;
 

--- a/src/Command/StatsTubeCommand.php
+++ b/src/Command/StatsTubeCommand.php
@@ -10,11 +10,9 @@ use Pheanstalk\YamlResponseParser;
  * Gives statistical information about the specified tube if it exists.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class StatsTubeCommand
-    extends AbstractCommand
+class StatsTubeCommand extends AbstractCommand
 {
     private $_tube;
 

--- a/src/Command/TouchCommand.php
+++ b/src/Command/TouchCommand.php
@@ -15,12 +15,9 @@ use Pheanstalk\Response;
  * (e.g. it may do this on DEADLINE_SOON).
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class TouchCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class TouchCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_job;
 

--- a/src/Command/UseCommand.php
+++ b/src/Command/UseCommand.php
@@ -12,12 +12,9 @@ use Pheanstalk\ResponseParser;
  * will be put into the tube named "default".
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class UseCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class UseCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     /**
      * @var string
@@ -45,8 +42,8 @@ class UseCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        return $this->_createResponse('USING', array(
+        return $this->_createResponse('USING', [
             'tube' => preg_replace('#^USING (.+)$#', '$1', $responseLine),
-        ));
+        ]);
     }
 }

--- a/src/Command/WatchCommand.php
+++ b/src/Command/WatchCommand.php
@@ -8,12 +8,9 @@ namespace Pheanstalk\Command;
  * Adds a tube to the watchlist to reserve jobs from.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class WatchCommand
-    extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+class WatchCommand extends AbstractCommand implements \Pheanstalk\ResponseParser
 {
     private $_tube;
 
@@ -38,8 +35,8 @@ class WatchCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        return $this->_createResponse('WATCHING', array(
+        return $this->_createResponse('WATCHING', [
             'count' => preg_replace('#^WATCHING (.+)$#', '$1', $responseLine),
-        ));
+        ]);
     }
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -8,7 +8,6 @@ use Pheanstalk\Socket\NativeSocket;
  * A connection to a beanstalkd server.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class Connection
@@ -18,20 +17,20 @@ class Connection
     const DEFAULT_CONNECT_TIMEOUT = 2;
 
     // responses which are global errors, mapped to their exception short-names
-    private static $_errorResponses = array(
+    private static $_errorResponses = [
         Response::RESPONSE_OUT_OF_MEMORY   => 'OutOfMemory',
         Response::RESPONSE_INTERNAL_ERROR  => 'InternalError',
         Response::RESPONSE_DRAINING        => 'Draining',
         Response::RESPONSE_BAD_FORMAT      => 'BadFormat',
         Response::RESPONSE_UNKNOWN_COMMAND => 'UnknownCommand',
-    );
+    ];
 
     // responses which are followed by data
-    private static $_dataResponses = array(
+    private static $_dataResponses = [
         Response::RESPONSE_RESERVED,
         Response::RESPONSE_FOUND,
         Response::RESPONSE_OK,
-    );
+    ];
 
     private $_socket;
     private $_hostname;

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -6,10 +6,8 @@ namespace Pheanstalk;
  * An exception originating from the Pheanstalk package.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class Exception
-    extends \Exception
+class Exception extends \Exception
 {
 }

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -8,10 +8,8 @@ use Pheanstalk\Exception;
  * An exception originating from the beanstalkd client.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ClientException
-    extends Exception
+class ClientException extends Exception
 {
 }

--- a/src/Exception/CommandException.php
+++ b/src/Exception/CommandException.php
@@ -6,10 +6,8 @@ namespace Pheanstalk\Exception;
  * An exception relating to a Command.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class CommandException
-    extends ClientException
+class CommandException extends ClientException
 {
 }

--- a/src/Exception/ConnectionException.php
+++ b/src/Exception/ConnectionException.php
@@ -6,11 +6,9 @@ namespace Pheanstalk\Exception;
  * An exception relating to the client connection to the beanstalkd server.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ConnectionException
-    extends ClientException
+class ConnectionException extends ClientException
 {
     /**
      * @param int    $errno  The connection error code

--- a/src/Exception/ServerBadFormatException.php
+++ b/src/Exception/ServerBadFormatException.php
@@ -6,10 +6,8 @@ namespace Pheanstalk\Exception;
  * An exception originating as a beanstalkd server error.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ServerBadFormatException
-    extends ServerException
+class ServerBadFormatException extends ServerException
 {
 }

--- a/src/Exception/ServerDrainingException.php
+++ b/src/Exception/ServerDrainingException.php
@@ -6,10 +6,8 @@ namespace Pheanstalk\Exception;
  * An exception originating as a beanstalkd server error.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ServerDrainingException
-    extends ServerException
+class ServerDrainingException extends ServerException
 {
 }

--- a/src/Exception/ServerException.php
+++ b/src/Exception/ServerException.php
@@ -8,10 +8,8 @@ use Pheanstalk\Exception;
  * An exception originating as a beanstalkd server error.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ServerException
-    extends Exception
+class ServerException extends Exception
 {
 }

--- a/src/Exception/ServerInternalErrorException.php
+++ b/src/Exception/ServerInternalErrorException.php
@@ -6,10 +6,8 @@ namespace Pheanstalk\Exception;
  * An exception originating as a beanstalkd server error.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ServerInternalErrorException
-    extends ServerException
+class ServerInternalErrorException extends ServerException
 {
 }

--- a/src/Exception/ServerOutOfMemoryException.php
+++ b/src/Exception/ServerOutOfMemoryException.php
@@ -6,10 +6,8 @@ namespace Pheanstalk\Exception;
  * An exception originating as a beanstalkd server error.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ServerOutOfMemoryException
-    extends ServerException
+class ServerOutOfMemoryException extends ServerException
 {
 }

--- a/src/Exception/ServerUnknownCommandException.php
+++ b/src/Exception/ServerUnknownCommandException.php
@@ -6,10 +6,8 @@ namespace Pheanstalk\Exception;
  * An exception originating as a beanstalkd server error.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ServerUnknownCommandException
-    extends ServerException
+class ServerUnknownCommandException extends ServerException
 {
 }

--- a/src/Exception/SocketException.php
+++ b/src/Exception/SocketException.php
@@ -6,10 +6,8 @@ namespace Pheanstalk\Exception;
  * An exception relating to the connection socket.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class SocketException
-    extends ClientException
+class SocketException extends ClientException
 {
 }

--- a/src/Job.php
+++ b/src/Job.php
@@ -6,7 +6,6 @@ namespace Pheanstalk;
  * A job in a beanstalkd server.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class Job

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -11,7 +11,6 @@ namespace Pheanstalk;
  * @see http://xph.us/software/beanstalkd/
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class Pheanstalk implements PheanstalkInterface
@@ -20,7 +19,7 @@ class Pheanstalk implements PheanstalkInterface
 
     private $_connection;
     private $_using = PheanstalkInterface::DEFAULT_TUBE;
-    private $_watching = array(PheanstalkInterface::DEFAULT_TUBE => true);
+    private $_watching = [PheanstalkInterface::DEFAULT_TUBE => true];
 
     /**
      * @param string $host
@@ -280,10 +279,10 @@ class Pheanstalk implements PheanstalkInterface
             new Command\ReserveCommand($timeout)
         );
 
-        $falseResponses = array(
+        $falseResponses = [
             Response::RESPONSE_DEADLINE_SOON,
             Response::RESPONSE_TIMED_OUT,
-        );
+        ];
 
         if (in_array($response->getResponseName(), $falseResponses)) {
             return false;
@@ -369,7 +368,7 @@ class Pheanstalk implements PheanstalkInterface
     {
         $this->watch($tube);
 
-        $ignoreTubes = array_diff_key($this->_watching, array($tube => true));
+        $ignoreTubes = array_diff_key($this->_watching, [$tube => true]);
         foreach ($ignoreTubes as $ignoreTube => $true) {
             $this->ignore($ignoreTube);
         }

--- a/src/Response.php
+++ b/src/Response.php
@@ -6,7 +6,6 @@ namespace Pheanstalk;
  * A response from the beanstalkd server.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 interface Response

--- a/src/Response/ArrayResponse.php
+++ b/src/Response/ArrayResponse.php
@@ -8,12 +8,9 @@ use Pheanstalk\Response;
  * A response with an ArrayObject interface to key => value data.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ArrayResponse
-    extends \ArrayObject
-    implements Response
+class ArrayResponse extends \ArrayObject implements Response
 {
     private $_name;
 

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -6,7 +6,6 @@ namespace Pheanstalk;
  * A parser for response data sent from the beanstalkd server.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 interface ResponseParser

--- a/src/Socket.php
+++ b/src/Socket.php
@@ -8,7 +8,6 @@ namespace Pheanstalk;
  * Only the subset of socket actions required by Pheanstalk are provided.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 interface Socket

--- a/src/Socket/NativeSocket.php
+++ b/src/Socket/NativeSocket.php
@@ -9,7 +9,6 @@ use Pheanstalk\Socket;
  * A Socket implementation around a fsockopen() stream.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class NativeSocket implements Socket
@@ -103,18 +102,17 @@ class NativeSocket implements Socket
             $data = isset($length) ?
                 $this->_wrapper()->fgets($this->_socket, $length) :
                 $this->_wrapper()->fgets($this->_socket);
-                
-               if($data === false) {
-				$info = $this->_wrapper()->stream_get_meta_data( $this->_socket );
 
-				//if time out occured and there are no unread bytes
-				//we might have socket connection to server lost
-				//a particualr case when remove host is no longer rechable
-				if ($info ['timed_out'] && $info['unread_bytes']==0) {
-					throw new Exception\SocketException ( "Socket connection lost" );
-				}
-			}
- 
+            if ($data === false) {
+                $info = $this->_wrapper()->stream_get_meta_data($this->_socket);
+
+                //if time out occured and there are no unread bytes
+                //we might have socket connection to server lost
+                //a particualr case when remove host is no longer rechable
+                if ($info['timed_out'] && $info['unread_bytes'] == 0) {
+                    throw new Exception\SocketException('Socket connection lost');
+                }
+            }
 
             if ($this->_wrapper()->feof($this->_socket)) {
                 throw new Exception\SocketException('Socket closed by server!');

--- a/src/Socket/NativeSocket.php
+++ b/src/Socket/NativeSocket.php
@@ -103,6 +103,18 @@ class NativeSocket implements Socket
             $data = isset($length) ?
                 $this->_wrapper()->fgets($this->_socket, $length) :
                 $this->_wrapper()->fgets($this->_socket);
+                
+               if($data === false) {
+				$info = $this->_wrapper()->stream_get_meta_data( $this->_socket );
+
+				//if time out occured and there are no unread bytes
+				//we might have socket connection to server lost
+				//a particualr case when remove host is no longer rechable
+				if ($info ['timed_out'] && $info['unread_bytes']==0) {
+					throw new Exception\SocketException ( "Socket connection lost" );
+				}
+			}
+ 
 
             if ($this->_wrapper()->feof($this->_socket)) {
                 throw new Exception\SocketException('Socket closed by server!');

--- a/src/Socket/StreamFunctions.php
+++ b/src/Socket/StreamFunctions.php
@@ -8,7 +8,6 @@ namespace Pheanstalk\Socket;
  * Facilitates mocking/stubbing stream operations in unit tests.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class StreamFunctions
@@ -97,9 +96,9 @@ class StreamFunctions
     {
         return stream_set_timeout($stream, $seconds, $microseconds);
     }
-    
+
     public function stream_get_meta_data($stream)
     {
-    	return stream_get_meta_data($stream);
+        return stream_get_meta_data($stream);
     }
 }

--- a/src/Socket/StreamFunctions.php
+++ b/src/Socket/StreamFunctions.php
@@ -97,4 +97,9 @@ class StreamFunctions
     {
         return stream_set_timeout($stream, $seconds, $microseconds);
     }
+    
+    public function stream_get_meta_data($stream)
+    {
+    	return stream_get_meta_data($stream);
+    }
 }

--- a/src/Socket/WriteHistory.php
+++ b/src/Socket/WriteHistory.php
@@ -14,13 +14,12 @@ namespace Pheanstalk\Socket;
  * A bitfield could be used instead of an array for efficiency.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class WriteHistory
 {
     private $_limit;
-    private $_data = array();
+    private $_data = [];
 
     /**
      * @param int $limit

--- a/src/YamlResponseParser.php
+++ b/src/YamlResponseParser.php
@@ -9,11 +9,9 @@ namespace Pheanstalk;
  * Parser expects either a YAML list or dictionary, depending on mode.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class YamlResponseParser
-    implements \Pheanstalk\ResponseParser
+class YamlResponseParser implements \Pheanstalk\ResponseParser
 {
     const MODE_LIST = 'list';
     const MODE_DICT = 'dict';
@@ -52,11 +50,11 @@ class YamlResponseParser
             array_shift($dataLines); // discard header line
         }
 
-        $data = array_map(array($this, '_mapYamlList'), $dataLines);
+        $data = array_map([$this, '_mapYamlList'], $dataLines);
 
         if ($this->_mode == self::MODE_DICT) {
             // TODO: do this better.
-            $array = array();
+            $array = [];
             foreach ($data as $line) {
                 if (!preg_match('#(\S+):\s*(.*)#', $line, $matches)) {
                     throw new Exception("YAML parse error for line: $line");

--- a/tests/Pheanstalk/BugfixConnectionTest.php
+++ b/tests/Pheanstalk/BugfixConnectionTest.php
@@ -10,7 +10,6 @@ namespace Pheanstalk;
  * @see http://github.com/pda/pheanstalk/issues
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class BugfixConnectionTest extends \PHPUnit_Framework_TestCase

--- a/tests/Pheanstalk/BugfixTest.php
+++ b/tests/Pheanstalk/BugfixTest.php
@@ -10,7 +10,6 @@ namespace Pheanstalk;
  * @see http://github.com/pda/pheanstalk/issues
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class BugfixTest extends \PHPUnit_Framework_TestCase
@@ -30,7 +29,7 @@ class BugfixTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK '.strlen($data), $data),
             Response::RESPONSE_OK,
-            array('pid' => '123', 'version' => '', 'key' => 'value')
+            ['pid' => '123', 'version' => '', 'key' => 'value']
         );
     }
 
@@ -42,7 +41,7 @@ class BugfixTest extends \PHPUnit_Framework_TestCase
      * @param string   $expectName
      * @param array    $data
      */
-    private function _assertResponse($response, $expectName, $data = array())
+    private function _assertResponse($response, $expectName, $data = [])
     {
         $this->assertEquals($response->getResponseName(), $expectName);
         $this->assertEquals($response->getArrayCopy(), $data);

--- a/tests/Pheanstalk/CommandTest.php
+++ b/tests/Pheanstalk/CommandTest.php
@@ -6,7 +6,6 @@ namespace Pheanstalk;
  * Tests for Command implementations.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class CommandTest extends \PHPUnit_Framework_TestCase
@@ -41,7 +40,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('WATCHING 2', null),
             Response::RESPONSE_WATCHING,
-            array('count' => 2)
+            ['count' => 2]
         );
     }
 
@@ -53,7 +52,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('KICKED 2', null),
             Response::RESPONSE_KICKED,
-            array('kicked' => 2)
+            ['kicked' => 2]
         );
     }
 
@@ -76,7 +75,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK 16', "---\n- one\n- two\n"),
             Response::RESPONSE_OK,
-            array('one', 'two')
+            ['one', 'two']
         );
     }
 
@@ -88,7 +87,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('USING default', null),
             Response::RESPONSE_USING,
-            array('tube' => 'default')
+            ['tube' => 'default']
         );
     }
 
@@ -101,7 +100,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('INSERTED 4', null),
             Response::RESPONSE_INSERTED,
-            array('id' => '4')
+            ['id' => '4']
         );
     }
 
@@ -125,7 +124,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('RESERVED 5 9', 'test data'),
             Response::RESPONSE_RESERVED,
-            array('id' => 5, 'jobdata' => 'test data')
+            ['id' => 5, 'jobdata' => 'test data']
         );
     }
 
@@ -137,7 +136,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('USING tube5', null),
             Response::RESPONSE_USING,
-            array('tube' => 'tube5')
+            ['tube' => 'tube5']
         );
     }
 
@@ -149,7 +148,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('WATCHING 3', null),
             Response::RESPONSE_WATCHING,
-            array('count' => '3')
+            ['count' => '3']
         );
     }
 
@@ -183,7 +182,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK 16', "---\n- one\n- two\n"),
             Response::RESPONSE_OK,
-            array('one', 'two')
+            ['one', 'two']
         );
     }
 
@@ -195,7 +194,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('FOUND 5 9', 'test data'),
             Response::RESPONSE_FOUND,
-            array('id' => 5, 'jobdata' => 'test data')
+            ['id' => 5, 'jobdata' => 'test data']
         );
     }
 
@@ -227,7 +226,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK '.strlen($data), $data),
             Response::RESPONSE_OK,
-            array('id' => '8', 'tube' => 'test', 'state' => 'delayed')
+            ['id' => '8', 'tube' => 'test', 'state' => 'delayed']
         );
     }
 
@@ -241,7 +240,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK '.strlen($data), $data),
             Response::RESPONSE_OK,
-            array('name' => 'test', 'current-jobs-ready' => '5')
+            ['name' => 'test', 'current-jobs-ready' => '5']
         );
     }
 
@@ -255,7 +254,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK '.strlen($data), $data),
             Response::RESPONSE_OK,
-            array('pid' => '123', 'version' => '1.3')
+            ['pid' => '123', 'version' => '1.3']
         );
     }
 
@@ -292,7 +291,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
      * @param string   $expectName
      * @param array    $data
      */
-    private function _assertResponse($response, $expectName, $data = array())
+    private function _assertResponse($response, $expectName, $data = [])
     {
         $this->assertEquals($response->getResponseName(), $expectName);
         $this->assertEquals($response->getArrayCopy(), $data);

--- a/tests/Pheanstalk/ConnectionTest.php
+++ b/tests/Pheanstalk/ConnectionTest.php
@@ -7,7 +7,6 @@ namespace Pheanstalk;
  * Relies on a running beanstalkd server.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class ConnectionTest extends \PHPUnit_Framework_TestCase

--- a/tests/Pheanstalk/ExceptionsTest.php
+++ b/tests/Pheanstalk/ExceptionsTest.php
@@ -6,7 +6,6 @@ namespace Pheanstalk;
  * Tests the Pheanstalk exceptions, mainly for parse errors etc.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class ExceptionsTest extends \PHPUnit_Framework_TestCase

--- a/tests/Pheanstalk/FacadeConnectionTest.php
+++ b/tests/Pheanstalk/FacadeConnectionTest.php
@@ -7,7 +7,6 @@ namespace Pheanstalk;
  * Relies on a running beanstalkd server.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class FacadeConnectionTest extends \PHPUnit_Framework_TestCase
@@ -39,20 +38,20 @@ class FacadeConnectionTest extends \PHPUnit_Framework_TestCase
     {
         $pheanstalk = $this->_getFacade();
 
-        $this->assertEquals($pheanstalk->listTubesWatched(), array('default'));
-        $this->assertEquals($pheanstalk->listTubesWatched(true), array('default'));
+        $this->assertEquals($pheanstalk->listTubesWatched(), ['default']);
+        $this->assertEquals($pheanstalk->listTubesWatched(true), ['default']);
 
         $pheanstalk->watch('test');
-        $this->assertEquals($pheanstalk->listTubesWatched(), array('default', 'test'));
-        $this->assertEquals($pheanstalk->listTubesWatched(true), array('default', 'test'));
+        $this->assertEquals($pheanstalk->listTubesWatched(), ['default', 'test']);
+        $this->assertEquals($pheanstalk->listTubesWatched(true), ['default', 'test']);
 
         $pheanstalk->ignore('default');
-        $this->assertEquals($pheanstalk->listTubesWatched(), array('test'));
-        $this->assertEquals($pheanstalk->listTubesWatched(true), array('test'));
+        $this->assertEquals($pheanstalk->listTubesWatched(), ['test']);
+        $this->assertEquals($pheanstalk->listTubesWatched(true), ['test']);
 
         $pheanstalk->watchOnly('default');
-        $this->assertEquals($pheanstalk->listTubesWatched(), array('default'));
-        $this->assertEquals($pheanstalk->listTubesWatched(true), array('default'));
+        $this->assertEquals($pheanstalk->listTubesWatched(), ['default']);
+        $this->assertEquals($pheanstalk->listTubesWatched(true), ['default']);
     }
 
     /**
@@ -334,7 +333,7 @@ class FacadeConnectionTest extends \PHPUnit_Framework_TestCase
 
         $stats = $pheanstalk->useTube('test-stats')->stats();
 
-        $properties = array('pid', 'cmd_put', 'cmd_stats_job');
+        $properties = ['pid', 'cmd_put', 'cmd_stats_job'];
         foreach ($properties as $property) {
             $this->assertTrue(
                 isset($stats->$property),

--- a/tests/Pheanstalk/NativeSocketTest.php
+++ b/tests/Pheanstalk/NativeSocketTest.php
@@ -9,7 +9,6 @@ use Pheanstalk\Socket\StreamFunctions;
  * Tests the Pheanstalk NativeSocket class.
  *
  * @author  SlNpacifist
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class NativeSocketTest extends \PHPUnit_Framework_TestCase

--- a/tests/Pheanstalk/ResponseParserExceptionTest.php
+++ b/tests/Pheanstalk/ResponseParserExceptionTest.php
@@ -6,7 +6,6 @@ namespace Pheanstalk;
  * Tests exceptions thrown by ResponseParser implementations.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class ResponseParserExceptionTest extends \PHPUnit_Framework_TestCase

--- a/tests/Pheanstalk/ServerErrorExceptionTest.php
+++ b/tests/Pheanstalk/ServerErrorExceptionTest.php
@@ -6,7 +6,6 @@ namespace Pheanstalk;
  * Tests exceptions thrown to represent non-command-specific error responses.
  *
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class ServerErrorExceptionTest extends \PHPUnit_Framework_TestCase

--- a/tests/Pheanstalk/SocketWriteHistoryTest.php
+++ b/tests/Pheanstalk/SocketWriteHistoryTest.php
@@ -6,7 +6,6 @@ use Pheanstalk\Socket\WriteHistory;
 
 /**
  * @author  Paul Annesley
- * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 class SocketWriteHistoryTest extends \PHPUnit_Framework_TestCase
@@ -76,12 +75,12 @@ class SocketWriteHistoryTest extends \PHPUnit_Framework_TestCase
     {
         $history = new WriteHistory(1);
 
-        foreach (array(null, false, 0, '', '0') as $input) {
+        foreach ([null, false, 0, '', '0'] as $input) {
             $this->assertEquals($history->log($input), $input);
             $this->assertTrue($history->isFullWithNoWrites());
         }
 
-        foreach (array(true, 1, 2, '1', '2') as $input) {
+        foreach ([true, 1, 2, '1', '2'] as $input) {
             $this->assertEquals($history->log($input), $input);
             $this->assertFalse($history->isFullWithNoWrites());
         }


### PR DESCRIPTION
Fixed :
In case of the remote beanstalk server goes unreachable , getLine() function goes into an infinite loop .
Now, added an extra check that , if there is any error , check if the timeout is there , and if so, try to re-connect to the server .
