### PR TITLE
Adding list() parameter for PHP7

### DIFF
--- a/src/YamlResponseParser.php
+++ b/src/YamlResponseParser.php
@@ -62,7 +62,7 @@ class YamlResponseParser
                     throw new Exception("YAML parse error for line: $line");
                 }
 
-                list(, $key, $value) = $matches;
+                list($unused, $key, $value) = $matches;
 
                 $array[$key] = $value;
             }


### PR DESCRIPTION
All list parameters are required for PHP7.