### PR TITLE
don't pass through connectPersistent bool to sockopen

### DIFF
--- a/src/Socket/NativeSocket.php
+++ b/src/Socket/NativeSocket.php
@@ -30,15 +30,16 @@ class NativeSocket implements Socket
      * @param string $host
      * @param int    $port
      * @param int    $connectTimeout
+     * @param bool   $connectPersistent
      */
     public function __construct($host, $port, $connectTimeout, $connectPersistent)
     {
         if ($connectPersistent) {
             $this->_socket = $this->_wrapper()
-                ->pfsockopen($host, $port, $errno, $errstr, $connectTimeout, $connectPersistent);
+                ->pfsockopen($host, $port, $errno, $errstr, $connectTimeout);
         } else {
             $this->_socket = $this->_wrapper()
-                ->fsockopen($host, $port, $errno, $errstr, $connectTimeout, $connectPersistent);
+                ->fsockopen($host, $port, $errno, $errstr, $connectTimeout);
         }
 
         if (!$this->_socket) {


### PR DESCRIPTION
Just something simple that caught my eye. `$connectPersistent` actually does not have to be passed through to the `fsockopen` or `pfsockopen` function calls.