### PR TITLE
Socket timeout detection

### DIFF
--- a/src/Socket/NativeSocket.php
+++ b/src/Socket/NativeSocket.php
@@ -100,7 +100,7 @@ class NativeSocket implements Socket
      */
     public function getLine($length = null)
     {
-        $timeout = ini_get('default-socket-timeout');
+        $timeout = ini_get('default_socket_timeout');
         $timer   = microtime(true);
         do {
             $data = isset($length) ?

--- a/src/Socket/NativeSocket.php
+++ b/src/Socket/NativeSocket.php
@@ -100,6 +100,8 @@ class NativeSocket implements Socket
      */
     public function getLine($length = null)
     {
+        $timeout = ini_get('default-socket-timeout');
+        $timer   = microtime(true);
         do {
             $data = isset($length) ?
                 $this->_wrapper()->fgets($this->_socket, $length) :
@@ -107,6 +109,10 @@ class NativeSocket implements Socket
 
             if ($this->_wrapper()->feof($this->_socket)) {
                 throw new Exception\SocketException('Socket closed by server!');
+            }
+            if (microtime(true) - $timer > $timeout) {
+                fclose($this->_socket);
+                throw new Exception\SocketException('Socket timed out!');
             }
         } while ($data === false);
 


### PR DESCRIPTION
This request is for the same problem as Socket timeout #152. Without modifying the interface definition of getLine, the use of php-ini's default-socket-timeout configuration item to the getLine function to add a timeout setting 