### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.8.35"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Pheanstalk/BugfixConnectionTest.php
+++ b/tests/Pheanstalk/BugfixConnectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for reported/discovered issues & bugs which don't fall into
  * an existing category of tests.
@@ -13,7 +15,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class BugfixConnectionTest extends \PHPUnit_Framework_TestCase
+class BugfixConnectionTest extends TestCase
 {
     const SERVER_HOST = 'localhost';
 

--- a/tests/Pheanstalk/BugfixTest.php
+++ b/tests/Pheanstalk/BugfixTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for reported/discovered issues & bugs which don't fall into
  * an existing category of tests.
@@ -13,7 +15,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class BugfixTest extends \PHPUnit_Framework_TestCase
+class BugfixTest extends TestCase
 {
     /**
      * Issue: Stats() Command fails if Version isn't set.

--- a/tests/Pheanstalk/CommandTest.php
+++ b/tests/Pheanstalk/CommandTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for Command implementations.
  *
@@ -9,7 +11,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class CommandTest extends \PHPUnit_Framework_TestCase
+class CommandTest extends TestCase
 {
     public function testBury()
     {

--- a/tests/Pheanstalk/ConnectionTest.php
+++ b/tests/Pheanstalk/ConnectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests for the Connection.
  * Relies on a running beanstalkd server.
@@ -10,7 +12,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ConnectionTest extends \PHPUnit_Framework_TestCase
+class ConnectionTest extends TestCase
 {
     const SERVER_HOST = 'localhost';
     const SERVER_PORT = '11300';

--- a/tests/Pheanstalk/ExceptionsTest.php
+++ b/tests/Pheanstalk/ExceptionsTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the Pheanstalk exceptions, mainly for parse errors etc.
  *
@@ -9,7 +11,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ExceptionsTest extends \PHPUnit_Framework_TestCase
+class ExceptionsTest extends TestCase
 {
     public function testPheanstalkException()
     {

--- a/tests/Pheanstalk/FacadeConnectionTest.php
+++ b/tests/Pheanstalk/FacadeConnectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests the Pheanstalk facade (the base class).
  * Relies on a running beanstalkd server.
@@ -10,7 +12,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class FacadeConnectionTest extends \PHPUnit_Framework_TestCase
+class FacadeConnectionTest extends TestCase
 {
     const SERVER_HOST = 'localhost';
 

--- a/tests/Pheanstalk/NativeSocketTest.php
+++ b/tests/Pheanstalk/NativeSocketTest.php
@@ -4,6 +4,7 @@ namespace Pheanstalk;
 
 use Pheanstalk\Socket\NativeSocket;
 use Pheanstalk\Socket\StreamFunctions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the Pheanstalk NativeSocket class.
@@ -12,7 +13,7 @@ use Pheanstalk\Socket\StreamFunctions;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class NativeSocketTest extends \PHPUnit_Framework_TestCase
+class NativeSocketTest extends TestCase
 {
     const DEFAULT_HOST = 'localhost';
     const DEFAULT_PORT = 11300;

--- a/tests/Pheanstalk/ResponseParserExceptionTest.php
+++ b/tests/Pheanstalk/ResponseParserExceptionTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests exceptions thrown by ResponseParser implementations.
  *
@@ -9,7 +11,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ResponseParserExceptionTest extends \PHPUnit_Framework_TestCase
+class ResponseParserExceptionTest extends TestCase
 {
     public function testDeleteNotFound()
     {

--- a/tests/Pheanstalk/ServerErrorExceptionTest.php
+++ b/tests/Pheanstalk/ServerErrorExceptionTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Tests exceptions thrown to represent non-command-specific error responses.
  *
@@ -9,7 +11,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class ServerErrorExceptionTest extends \PHPUnit_Framework_TestCase
+class ServerErrorExceptionTest extends TestCase
 {
     private $_command;
 

--- a/tests/Pheanstalk/SocketWriteHistoryTest.php
+++ b/tests/Pheanstalk/SocketWriteHistoryTest.php
@@ -3,13 +3,14 @@
 namespace Pheanstalk;
 
 use Pheanstalk\Socket\WriteHistory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author  Paul Annesley
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class SocketWriteHistoryTest extends \PHPUnit_Framework_TestCase
+class SocketWriteHistoryTest extends TestCase
 {
     public function testEmptyHistory()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.