### PR TITLE
WIP: V4 cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pheanstalk.phar
 vendor/
 # Test coverage is stored here
 tests/coverage
+.idea

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -2,8 +2,9 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\Command;
-use Pheanstalk\Response;
+use Pheanstalk\Contract\CommandInterface;
+use Pheanstalk\Exception\CommandException;
+use Pheanstalk\Response\ArrayResponse;
 
 /**
  * Common functionality for Command implementations.
@@ -13,7 +14,7 @@ use Pheanstalk\Response;
  * @license http://www.opensource.org/licenses/mit-license.php
  */
 abstract class AbstractCommand
-    implements Command
+    implements CommandInterface
 {
     /* (non-phpdoc)
      * @see Command::hasData()
@@ -28,7 +29,7 @@ abstract class AbstractCommand
      */
     public function getData()
     {
-        throw new Exception\CommandException('Command has no data');
+        throw new CommandException('Command has no data');
     }
 
     /* (non-phpdoc)
@@ -36,7 +37,7 @@ abstract class AbstractCommand
      */
     public function getDataLength()
     {
-        throw new Exception\CommandException('Command has no data');
+        throw new CommandException('Command has no data');
     }
 
     /* (non-phpdoc)
@@ -72,6 +73,6 @@ abstract class AbstractCommand
      */
     protected function _createResponse($name, $data = array())
     {
-        return new Response\ArrayResponse($name, $data);
+        return new ArrayResponse($name, $data);
     }
 }

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -3,6 +3,7 @@
 namespace Pheanstalk\Command;
 
 use Pheanstalk\Contract\CommandInterface;
+use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception\CommandException;
 use Pheanstalk\Response\ArrayResponse;
 
@@ -69,9 +70,8 @@ abstract class AbstractCommand
      *
      * @param array
      *
-     * @return object Response
      */
-    protected function _createResponse($name, $data = array())
+    protected function createResponse(string $name, array $data = []): ArrayResponse
     {
         return new ArrayResponse($name, $data);
     }

--- a/src/Command/BuryCommand.php
+++ b/src/Command/BuryCommand.php
@@ -55,7 +55,7 @@ class BuryCommand
                 $this->_job->getId()
             ));
         } elseif ($responseLine == ResponseInterface::RESPONSE_BURIED) {
-            return $this->_createResponse(ResponseInterface::RESPONSE_BURIED);
+            return $this->createResponse(ResponseInterface::RESPONSE_BURIED);
         } else {
             throw new Exception('Unhandled response: '.$responseLine);
         }

--- a/src/Command/BuryCommand.php
+++ b/src/Command/BuryCommand.php
@@ -2,8 +2,8 @@
 
 namespace Pheanstalk\Command;
 
+use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception;
-use Pheanstalk\Response;
 
 /**
  * The 'bury' command.
@@ -16,7 +16,7 @@ use Pheanstalk\Response;
  */
 class BuryCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_job;
     private $_priority;
@@ -48,14 +48,14 @@ class BuryCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        if ($responseLine == Response::RESPONSE_NOT_FOUND) {
+        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\ServerException(sprintf(
                 '%s: Job %u is not reserved or does not exist.',
                 $responseLine,
                 $this->_job->getId()
             ));
-        } elseif ($responseLine == Response::RESPONSE_BURIED) {
-            return $this->_createResponse(Response::RESPONSE_BURIED);
+        } elseif ($responseLine == ResponseInterface::RESPONSE_BURIED) {
+            return $this->_createResponse(ResponseInterface::RESPONSE_BURIED);
         } else {
             throw new Exception('Unhandled response: '.$responseLine);
         }

--- a/src/Command/DeleteCommand.php
+++ b/src/Command/DeleteCommand.php
@@ -2,8 +2,8 @@
 
 namespace Pheanstalk\Command;
 
+use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception;
-use Pheanstalk\Response;
 
 /**
  * The 'delete' command.
@@ -16,7 +16,7 @@ use Pheanstalk\Response;
  */
 class DeleteCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_job;
 
@@ -41,7 +41,7 @@ class DeleteCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        if ($responseLine == Response::RESPONSE_NOT_FOUND) {
+        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\ServerException(sprintf(
                 'Cannot delete job %u: %s',
                 $this->_job->getId(),

--- a/src/Command/DeleteCommand.php
+++ b/src/Command/DeleteCommand.php
@@ -49,6 +49,6 @@ class DeleteCommand
             ));
         }
 
-        return $this->_createResponse($responseLine);
+        return $this->createResponse($responseLine);
     }
 }

--- a/src/Command/IgnoreCommand.php
+++ b/src/Command/IgnoreCommand.php
@@ -2,8 +2,8 @@
 
 namespace Pheanstalk\Command;
 
+use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception;
-use Pheanstalk\Response;
 
 /**
  * The 'ignore' command.
@@ -16,7 +16,7 @@ use Pheanstalk\Response;
  */
 class IgnoreCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_tube;
 
@@ -45,7 +45,7 @@ class IgnoreCommand
             return $this->_createResponse('WATCHING', array(
                 'count' => (int) $matches[1],
             ));
-        } elseif ($responseLine == Response::RESPONSE_NOT_IGNORED) {
+        } elseif ($responseLine == ResponseInterface::RESPONSE_NOT_IGNORED) {
             throw new Exception\ServerException(
                 $responseLine.': cannot ignore last tube in watchlist'
             );

--- a/src/Command/IgnoreCommand.php
+++ b/src/Command/IgnoreCommand.php
@@ -42,7 +42,7 @@ class IgnoreCommand
     public function parseResponse($responseLine, $responseData)
     {
         if (preg_match('#^WATCHING (\d+)$#', $responseLine, $matches)) {
-            return $this->_createResponse('WATCHING', array(
+            return $this->createResponse('WATCHING', array(
                 'count' => (int) $matches[1],
             ));
         } elseif ($responseLine == ResponseInterface::RESPONSE_NOT_IGNORED) {

--- a/src/Command/KickCommand.php
+++ b/src/Command/KickCommand.php
@@ -15,7 +15,7 @@ namespace Pheanstalk\Command;
  */
 class KickCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_max;
 

--- a/src/Command/KickCommand.php
+++ b/src/Command/KickCommand.php
@@ -42,7 +42,7 @@ class KickCommand
     {
         list($code, $count) = explode(' ', $responseLine);
 
-        return $this->_createResponse($code, array(
+        return $this->createResponse($code, array(
             'kicked' => (int) $count,
         ));
     }

--- a/src/Command/KickJobCommand.php
+++ b/src/Command/KickJobCommand.php
@@ -52,7 +52,7 @@ class KickJobCommand
                 $this->_job->getId()
             ));
         } elseif ($responseLine == ResponseInterface::RESPONSE_KICKED) {
-            return $this->_createResponse(ResponseInterface::RESPONSE_KICKED);
+            return $this->createResponse(ResponseInterface::RESPONSE_KICKED);
         } else {
             throw new Exception('Unhandled response: '.$responseLine);
         }

--- a/src/Command/KickJobCommand.php
+++ b/src/Command/KickJobCommand.php
@@ -2,8 +2,8 @@
 
 namespace Pheanstalk\Command;
 
+use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception;
-use Pheanstalk\Response;
 
 /**
  * The 'kick-job' command.
@@ -20,7 +20,7 @@ use Pheanstalk\Response;
  */
 class KickJobCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_job;
 
@@ -45,14 +45,14 @@ class KickJobCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        if ($responseLine == Response::RESPONSE_NOT_FOUND) {
+        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\ServerException(sprintf(
                 '%s: Job %d does not exist or is not in a kickable state.',
                 $responseLine,
                 $this->_job->getId()
             ));
-        } elseif ($responseLine == Response::RESPONSE_KICKED) {
-            return $this->_createResponse(Response::RESPONSE_KICKED);
+        } elseif ($responseLine == ResponseInterface::RESPONSE_KICKED) {
+            return $this->_createResponse(ResponseInterface::RESPONSE_KICKED);
         } else {
             throw new Exception('Unhandled response: '.$responseLine);
         }

--- a/src/Command/ListTubeUsedCommand.php
+++ b/src/Command/ListTubeUsedCommand.php
@@ -28,7 +28,7 @@ class ListTubeUsedCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        return $this->_createResponse('USING', array(
+        return $this->createResponse('USING', array(
             'tube' => preg_replace('#^USING (.+)$#', '$1', $responseLine),
         ));
     }

--- a/src/Command/ListTubeUsedCommand.php
+++ b/src/Command/ListTubeUsedCommand.php
@@ -13,7 +13,7 @@ namespace Pheanstalk\Command;
  */
 class ListTubeUsedCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     /* (non-phpdoc)
      * @see Command::getCommandLine()

--- a/src/Command/ListTubesCommand.php
+++ b/src/Command/ListTubesCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\YamlResponseParser;
+use Pheanstalk\Contract\YamlResponseParserInterface;
 
 /**
  * The 'list-tubes' command.
@@ -29,8 +29,8 @@ class ListTubesCommand
      */
     public function getResponseParser()
     {
-        return new YamlResponseParser(
-            YamlResponseParser::MODE_LIST
+        return new YamlResponseParserInterface(
+            YamlResponseParserInterface::MODE_LIST
         );
     }
 }

--- a/src/Command/ListTubesCommand.php
+++ b/src/Command/ListTubesCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\Contract\YamlResponseParserInterface;
+use Pheanstalk\YamlResponseParser;
 
 /**
  * The 'list-tubes' command.
@@ -29,8 +29,8 @@ class ListTubesCommand
      */
     public function getResponseParser()
     {
-        return new YamlResponseParserInterface(
-            YamlResponseParserInterface::MODE_LIST
+        return new YamlResponseParser(
+            YamlResponseParser::MODE_LIST
         );
     }
 }

--- a/src/Command/ListTubesWatchedCommand.php
+++ b/src/Command/ListTubesWatchedCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\YamlResponseParser;
+use Pheanstalk\Contract\YamlResponseParserInterface;
 
 /**
  * The 'list-tubes-watched' command.
@@ -29,8 +29,8 @@ class ListTubesWatchedCommand
      */
     public function getResponseParser()
     {
-        return new YamlResponseParser(
-            YamlResponseParser::MODE_LIST
+        return new YamlResponseParserInterface(
+            YamlResponseParserInterface::MODE_LIST
         );
     }
 }

--- a/src/Command/ListTubesWatchedCommand.php
+++ b/src/Command/ListTubesWatchedCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\Contract\YamlResponseParserInterface;
+use Pheanstalk\YamlResponseParser;
 
 /**
  * The 'list-tubes-watched' command.
@@ -29,8 +29,8 @@ class ListTubesWatchedCommand
      */
     public function getResponseParser()
     {
-        return new YamlResponseParserInterface(
-            YamlResponseParserInterface::MODE_LIST
+        return new YamlResponseParser(
+            YamlResponseParser::MODE_LIST
         );
     }
 }

--- a/src/Command/PauseTubeCommand.php
+++ b/src/Command/PauseTubeCommand.php
@@ -2,8 +2,8 @@
 
 namespace Pheanstalk\Command;
 
+use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception;
-use Pheanstalk\Response;
 
 /**
  * The 'pause-tube' command.
@@ -16,7 +16,7 @@ use Pheanstalk\Response;
  */
 class PauseTubeCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_tube;
     private $_delay;
@@ -48,14 +48,14 @@ class PauseTubeCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        if ($responseLine == Response::RESPONSE_NOT_FOUND) {
+        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\ServerException(sprintf(
                 '%s: tube %s does not exist.',
                 $responseLine,
                 $this->_tube
             ));
-        } elseif ($responseLine == Response::RESPONSE_PAUSED) {
-            return $this->_createResponse(Response::RESPONSE_PAUSED);
+        } elseif ($responseLine == ResponseInterface::RESPONSE_PAUSED) {
+            return $this->_createResponse(ResponseInterface::RESPONSE_PAUSED);
         } else {
             throw new Exception('Unhandled response: '.$responseLine);
         }

--- a/src/Command/PauseTubeCommand.php
+++ b/src/Command/PauseTubeCommand.php
@@ -55,7 +55,7 @@ class PauseTubeCommand
                 $this->_tube
             ));
         } elseif ($responseLine == ResponseInterface::RESPONSE_PAUSED) {
-            return $this->_createResponse(ResponseInterface::RESPONSE_PAUSED);
+            return $this->createResponse(ResponseInterface::RESPONSE_PAUSED);
         } else {
             throw new Exception('Unhandled response: '.$responseLine);
         }

--- a/src/Command/PeekCommand.php
+++ b/src/Command/PeekCommand.php
@@ -2,8 +2,8 @@
 
 namespace Pheanstalk\Command;
 
+use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception;
-use Pheanstalk\Response;
 
 /**
  * The 'peek', 'peek-ready', 'peek-delayed' and 'peek-buried' commands.
@@ -17,7 +17,7 @@ use Pheanstalk\Response;
  */
 class PeekCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     const TYPE_ID = 'id';
     const TYPE_READY = 'ready';
@@ -64,7 +64,7 @@ class PeekCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        if ($responseLine == Response::RESPONSE_NOT_FOUND) {
+        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             if (isset($this->_jobId)) {
                 $message = sprintf(
                     '%s: Job %u does not exist.',
@@ -82,7 +82,7 @@ class PeekCommand
             throw new Exception\ServerException($message);
         } elseif (preg_match('#^FOUND (\d+) \d+$#', $responseLine, $matches)) {
             return $this->_createResponse(
-                Response::RESPONSE_FOUND,
+                ResponseInterface::RESPONSE_FOUND,
                 array(
                     'id'      => (int) $matches[1],
                     'jobdata' => $responseData,

--- a/src/Command/PeekJobCommand.php
+++ b/src/Command/PeekJobCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Pheanstalk\Command;
+
+use Pheanstalk\Contract\JobIdInterface;
+use Pheanstalk\Contract\ResponseInterface;
+use Pheanstalk\Exception;
+
+/**
+ * The 'peek' command.
+ *
+ * The peek command let the client inspect a specific job in the system.
+ *
+ * @author  Paul Annesley
+ * @package Pheanstalk
+ * @license http://www.opensource.org/licenses/mit-license.php
+ */
+class PeekJobCommand
+    extends AbstractCommand
+    implements \Pheanstalk\Contract\ResponseParserInterface
+{
+    private $jobId;
+
+    /**
+     * @param mixed $peekSubject Job ID or self::TYPE_*
+     */
+    public function __construct(JobIdInterface $peekSubject)
+    {
+        $this->jobId = $peekSubject->getId();
+    }
+
+    /* (non-phpdoc)
+     * @see Command::getCommandLine()
+     */
+    public function getCommandLine()
+    {
+        return sprintf('peek %u', $this->jobId);
+    }
+
+    /* (non-phpdoc)
+     * @see ResponseParser::parseResponse()
+     */
+    public function parseResponse($responseLine, $responseData)
+    {
+        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
+            $message = sprintf(
+                '%s: Job %u does not exist.',
+                $responseLine,
+                $this->jobId
+            );
+            throw new Exception\ServerException($message);
+        } elseif (preg_match('#^FOUND (\d+) \d+$#', $responseLine, $matches)) {
+            return $this->createResponse(
+                ResponseInterface::RESPONSE_FOUND,
+                [
+                    'id'      => (int) $matches[1],
+                    'jobdata' => $responseData,
+                ]
+            );
+        }
+    }
+}

--- a/src/Command/PutCommand.php
+++ b/src/Command/PutCommand.php
@@ -88,7 +88,7 @@ class PutCommand
     public function parseResponse($responseLine, $responseData)
     {
         if (preg_match('#^INSERTED (\d+)$#', $responseLine, $matches)) {
-            return $this->_createResponse('INSERTED', array(
+            return $this->createResponse('INSERTED', array(
                 'id' => (int) $matches[1],
             ));
         } elseif (preg_match('#^BURIED (\d)+$#', $responseLine, $matches)) {

--- a/src/Command/PutCommand.php
+++ b/src/Command/PutCommand.php
@@ -17,7 +17,7 @@ use Pheanstalk\Exception;
  */
 class PutCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_data;
     private $_priority;

--- a/src/Command/ReleaseCommand.php
+++ b/src/Command/ReleaseCommand.php
@@ -2,8 +2,8 @@
 
 namespace Pheanstalk\Command;
 
+use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception;
-use Pheanstalk\Response;
 
 /**
  * The 'release' command.
@@ -16,7 +16,7 @@ use Pheanstalk\Response;
  */
 class ReleaseCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_job;
     private $_priority;
@@ -52,7 +52,7 @@ class ReleaseCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        if ($responseLine == Response::RESPONSE_BURIED) {
+        if ($responseLine == ResponseInterface::RESPONSE_BURIED) {
             throw new Exception\ServerException(sprintf(
                 'Job %u %s: out of memory trying to grow data structure',
                 $this->_job->getId(),
@@ -60,7 +60,7 @@ class ReleaseCommand
             ));
         }
 
-        if ($responseLine == Response::RESPONSE_NOT_FOUND) {
+        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\ServerException(sprintf(
                 'Job %u %s: does not exist or is not reserved by client',
                 $this->_job->getId(),

--- a/src/Command/ReleaseCommand.php
+++ b/src/Command/ReleaseCommand.php
@@ -68,6 +68,6 @@ class ReleaseCommand
             ));
         }
 
-        return $this->_createResponse($responseLine);
+        return $this->createResponse($responseLine);
     }
 }

--- a/src/Command/ReserveCommand.php
+++ b/src/Command/ReserveCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\Response;
+use Pheanstalk\Contract\ResponseInterface;
 
 /**
  * The 'reserve' command.
@@ -15,7 +15,7 @@ use Pheanstalk\Response;
  */
 class ReserveCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_timeout;
 
@@ -47,7 +47,7 @@ class ReserveCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        if (in_array($responseLine, array(Response::RESPONSE_DEADLINE_SOON, Response::RESPONSE_TIMED_OUT), true)) {
+        if (in_array($responseLine, array(ResponseInterface::RESPONSE_DEADLINE_SOON, ResponseInterface::RESPONSE_TIMED_OUT), true)) {
             return $this->_createResponse($responseLine);
         }
 

--- a/src/Command/ReserveCommand.php
+++ b/src/Command/ReserveCommand.php
@@ -48,12 +48,12 @@ class ReserveCommand
     public function parseResponse($responseLine, $responseData)
     {
         if (in_array($responseLine, array(ResponseInterface::RESPONSE_DEADLINE_SOON, ResponseInterface::RESPONSE_TIMED_OUT), true)) {
-            return $this->_createResponse($responseLine);
+            return $this->createResponse($responseLine);
         }
 
         list($code, $id) = explode(' ', $responseLine);
 
-        return $this->_createResponse($code, array(
+        return $this->createResponse($code, array(
             'id'      => (int) $id,
             'jobdata' => $responseData,
         ));

--- a/src/Command/StatsCommand.php
+++ b/src/Command/StatsCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\YamlResponseParser;
+use Pheanstalk\Contract\YamlResponseParserInterface;
 
 /**
  * The 'stats' command.
@@ -29,8 +29,8 @@ class StatsCommand
      */
     public function getResponseParser()
     {
-        return new YamlResponseParser(
-            YamlResponseParser::MODE_DICT
+        return new YamlResponseParserInterface(
+            YamlResponseParserInterface::MODE_DICT
         );
     }
 }

--- a/src/Command/StatsCommand.php
+++ b/src/Command/StatsCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\Contract\YamlResponseParserInterface;
+use Pheanstalk\YamlResponseParser;
 
 /**
  * The 'stats' command.
@@ -29,8 +29,8 @@ class StatsCommand
      */
     public function getResponseParser()
     {
-        return new YamlResponseParserInterface(
-            YamlResponseParserInterface::MODE_DICT
+        return new YamlResponseParser(
+            YamlResponseParser::MODE_DICT
         );
     }
 }

--- a/src/Command/StatsJobCommand.php
+++ b/src/Command/StatsJobCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\Contract\YamlResponseParserInterface;
+use Pheanstalk\YamlResponseParser;
 
 /**
  * The 'stats-job' command.
@@ -39,8 +39,8 @@ class StatsJobCommand
      */
     public function getResponseParser()
     {
-        return new YamlResponseParserInterface(
-            YamlResponseParserInterface::MODE_DICT
+        return new YamlResponseParser(
+            YamlResponseParser::MODE_DICT
         );
     }
 }

--- a/src/Command/StatsJobCommand.php
+++ b/src/Command/StatsJobCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\YamlResponseParser;
+use Pheanstalk\Contract\YamlResponseParserInterface;
 
 /**
  * The 'stats-job' command.
@@ -39,8 +39,8 @@ class StatsJobCommand
      */
     public function getResponseParser()
     {
-        return new YamlResponseParser(
-            YamlResponseParser::MODE_DICT
+        return new YamlResponseParserInterface(
+            YamlResponseParserInterface::MODE_DICT
         );
     }
 }

--- a/src/Command/StatsTubeCommand.php
+++ b/src/Command/StatsTubeCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\YamlResponseParser;
+use Pheanstalk\Contract\YamlResponseParserInterface;
 
 /**
  * The 'stats-tube' command.
@@ -39,8 +39,8 @@ class StatsTubeCommand
      */
     public function getResponseParser()
     {
-        return new YamlResponseParser(
-            YamlResponseParser::MODE_DICT
+        return new YamlResponseParserInterface(
+            YamlResponseParserInterface::MODE_DICT
         );
     }
 }

--- a/src/Command/StatsTubeCommand.php
+++ b/src/Command/StatsTubeCommand.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\Contract\YamlResponseParserInterface;
+use Pheanstalk\YamlResponseParser;
 
 /**
  * The 'stats-tube' command.
@@ -39,8 +39,8 @@ class StatsTubeCommand
      */
     public function getResponseParser()
     {
-        return new YamlResponseParserInterface(
-            YamlResponseParserInterface::MODE_DICT
+        return new YamlResponseParser(
+            YamlResponseParser::MODE_DICT
         );
     }
 }

--- a/src/Command/TouchCommand.php
+++ b/src/Command/TouchCommand.php
@@ -2,6 +2,7 @@
 
 namespace Pheanstalk\Command;
 
+use Pheanstalk\Contract\JobIdInterface;
 use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception;
 
@@ -22,14 +23,11 @@ class TouchCommand
     extends AbstractCommand
     implements \Pheanstalk\Contract\ResponseParserInterface
 {
-    private $_job;
+    private $jobId;
 
-    /**
-     * @param Job $job
-     */
-    public function __construct($job)
+    public function __construct(JobIdInterface $job)
     {
-        $this->_job = $job;
+        $this->jobId = $job->getId();
     }
 
     /* (non-phpdoc)
@@ -37,7 +35,7 @@ class TouchCommand
      */
     public function getCommandLine()
     {
-        return sprintf('touch %u', $this->_job->getId());
+        return sprintf('touch %u', $this->jobId);
     }
 
     /* (non-phpdoc)
@@ -48,7 +46,7 @@ class TouchCommand
         if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\ServerException(sprintf(
                 'Job %u %s: does not exist or is not reserved by client',
-                $this->_job->getId(),
+                $this->jobId,
                 $responseLine
             ));
         }

--- a/src/Command/TouchCommand.php
+++ b/src/Command/TouchCommand.php
@@ -2,8 +2,8 @@
 
 namespace Pheanstalk\Command;
 
+use Pheanstalk\Contract\ResponseInterface;
 use Pheanstalk\Exception;
-use Pheanstalk\Response;
 
 /**
  * The 'touch' command.
@@ -20,7 +20,7 @@ use Pheanstalk\Response;
  */
 class TouchCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_job;
 
@@ -45,7 +45,7 @@ class TouchCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        if ($responseLine == Response::RESPONSE_NOT_FOUND) {
+        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\ServerException(sprintf(
                 'Job %u %s: does not exist or is not reserved by client',
                 $this->_job->getId(),

--- a/src/Command/TouchCommand.php
+++ b/src/Command/TouchCommand.php
@@ -53,6 +53,6 @@ class TouchCommand
             ));
         }
 
-        return $this->_createResponse($responseLine);
+        return $this->createResponse($responseLine);
     }
 }

--- a/src/Command/UseCommand.php
+++ b/src/Command/UseCommand.php
@@ -2,8 +2,6 @@
 
 namespace Pheanstalk\Command;
 
-use Pheanstalk\ResponseParser;
-
 /**
  * The 'use' command.
  *
@@ -17,7 +15,7 @@ use Pheanstalk\ResponseParser;
  */
 class UseCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     /**
      * @var string

--- a/src/Command/UseCommand.php
+++ b/src/Command/UseCommand.php
@@ -43,7 +43,7 @@ class UseCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        return $this->_createResponse('USING', array(
+        return $this->createResponse('USING', array(
             'tube' => preg_replace('#^USING (.+)$#', '$1', $responseLine),
         ));
     }

--- a/src/Command/WatchCommand.php
+++ b/src/Command/WatchCommand.php
@@ -38,7 +38,7 @@ class WatchCommand
      */
     public function parseResponse($responseLine, $responseData)
     {
-        return $this->_createResponse('WATCHING', array(
+        return $this->createResponse('WATCHING', array(
             'count' => preg_replace('#^WATCHING (.+)$#', '$1', $responseLine),
         ));
     }

--- a/src/Command/WatchCommand.php
+++ b/src/Command/WatchCommand.php
@@ -13,7 +13,7 @@ namespace Pheanstalk\Command;
  */
 class WatchCommand
     extends AbstractCommand
-    implements \Pheanstalk\ResponseParser
+    implements \Pheanstalk\Contract\ResponseParserInterface
 {
     private $_tube;
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use Pheanstalk\Contract\ResponseInterface;
+use Pheanstalk\Contract\SocketInterface;
 use Pheanstalk\Socket\NativeSocket;
 
 /**
@@ -19,18 +21,18 @@ class Connection
 
     // responses which are global errors, mapped to their exception short-names
     private static $_errorResponses = array(
-        Response::RESPONSE_OUT_OF_MEMORY   => 'OutOfMemory',
-        Response::RESPONSE_INTERNAL_ERROR  => 'InternalError',
-        Response::RESPONSE_DRAINING        => 'Draining',
-        Response::RESPONSE_BAD_FORMAT      => 'BadFormat',
-        Response::RESPONSE_UNKNOWN_COMMAND => 'UnknownCommand',
+        ResponseInterface::RESPONSE_OUT_OF_MEMORY   => 'OutOfMemory',
+        ResponseInterface::RESPONSE_INTERNAL_ERROR  => 'InternalError',
+        ResponseInterface::RESPONSE_DRAINING        => 'Draining',
+        ResponseInterface::RESPONSE_BAD_FORMAT      => 'BadFormat',
+        ResponseInterface::RESPONSE_UNKNOWN_COMMAND => 'UnknownCommand',
     );
 
     // responses which are followed by data
     private static $_dataResponses = array(
-        Response::RESPONSE_RESERVED,
-        Response::RESPONSE_FOUND,
-        Response::RESPONSE_OK,
+        ResponseInterface::RESPONSE_RESERVED,
+        ResponseInterface::RESPONSE_FOUND,
+        ResponseInterface::RESPONSE_OK,
     );
 
     private $_socket;
@@ -60,11 +62,11 @@ class Connection
     /**
      * Sets a manually created socket, used for unit testing.
      *
-     * @param Socket $socket
+     * @param SocketInterface $socket
      *
      * @return $this
      */
-    public function setSocket(Socket $socket)
+    public function setSocket(SocketInterface $socket)
     {
         $this->_socket = $socket;
 
@@ -182,7 +184,7 @@ class Connection
      *
      * @throws Exception\ConnectionException
      *
-     * @return Socket
+     * @return SocketInterface
      */
     private function _getSocket()
     {

--- a/src/Contract/CommandInterface.php
+++ b/src/Contract/CommandInterface.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Pheanstalk;
+namespace Pheanstalk\Contract;
+
+use Pheanstalk\Exception;
 
 /**
  * A command to be sent to the beanstalkd server, and response processing logic.
@@ -9,7 +11,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-interface Command
+interface CommandInterface
 {
     const COMMAND_PUT = 'put';
     const COMMAND_USE = 'use';
@@ -62,7 +64,7 @@ interface Command
     /**
      * The response parser for the command.
      *
-     * @return ResponseParser
+     * @return ResponseParserInterface
      */
     public function getResponseParser();
 }

--- a/src/Contract/JobIdInterface.php
+++ b/src/Contract/JobIdInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Pheanstalk\Contract;
+
+
+interface JobIdInterface
+{
+    public function getId(): int;
+}

--- a/src/Contract/PheanstalkInterface.php
+++ b/src/Contract/PheanstalkInterface.php
@@ -128,26 +128,20 @@ interface PheanstalkInterface
     public function peek(JobIdInterface $job): Job;
 
     /**
-     * Inspect the next ready job in the specified tube. If no tube is
-     * specified, the currently used tube in used.
+     * Inspect the next ready job in the currently used tube.
      */
-    public function peekReady(?string $tube = null): Job;
+    public function peekReady(): ?Job;
 
     /**
-     * Inspect the shortest-remaining-delayed job in the specified tube. If no
-     * tube is specified, the currently used tube in used.
-     *
-     * @param string $tube
-     *
-     * @return object Job
+     * Inspect the shortest-remaining-delayed job in the currently used tube.
+     * @return ?Job
      */
-    public function peekDelayed(?string $tube = null): Job;
+    public function peekDelayed(): ?Job;
 
     /**
-     * Inspect the next job in the list of buried jobs of the specified tube.
-     * If no tube is specified, the currently used tube in used.
+     * Inspect the next job in the list of buried jobs in the currently used tube.
      */
-    public function peekBuried(?string $tube = null): Job;
+    public function peekBuried(): ?Job;
 
     /**
      * Puts a job on the queue.
@@ -156,33 +150,8 @@ interface PheanstalkInterface
      * @param int    $priority From 0 (most urgent) to 0xFFFFFFFF (least urgent)
      * @param int    $delay    Seconds to wait before job becomes ready
      * @param int    $ttr      Time To Run: seconds a job can be reserved for
-     *
-     * @return int The new job ID
      */
     public function put(
-        string $data,
-        int $priority = self::DEFAULT_PRIORITY,
-        int $delay = self::DEFAULT_DELAY,
-        int $ttr = self::DEFAULT_TTR
-    ): Job;
-
-    /**
-     * Puts a job on the queue using specified tube.
-     *
-     * Using this method is equivalent to calling useTube() then put(), with
-     * the added benefit that it will not execute the USE command if the client
-     * is already using the specified tube.
-     *
-     * @param string $tube     The tube to use
-     * @param string $data     The job data
-     * @param int    $priority From 0 (most urgent) to 0xFFFFFFFF (least urgent)
-     * @param int    $delay    Seconds to wait before job becomes ready
-     * @param int    $ttr      Time To Run: seconds a job can be reserved for
-     *
-     * @return int The new job ID
-     */
-    public function putInTube(
-        string $tube,
         string $data,
         int $priority = self::DEFAULT_PRIORITY,
         int $delay = self::DEFAULT_DELAY,
@@ -198,8 +167,6 @@ interface PheanstalkInterface
      * @param JobIdInterface $job
      * @param int $priority From 0 (most urgent) to 0xFFFFFFFF (least urgent)
      * @param int $delay Seconds to wait before job becomes ready
-     *
-     * @return $this
      */
     public function release(
         JobIdInterface $job,
@@ -209,57 +176,31 @@ interface PheanstalkInterface
 
     /**
      * Reserves/locks a ready job in a watched tube.
-     *
-     * A non-null timeout uses the 'reserve-with-timeout' instead of 'reserve'.
-     *
-     * A timeout value of 0 will cause the server to immediately return either a
-     * response or TIMED_OUT.  A positive value of timeout will limit the amount of
-     * time the client will block on the reserve request until a job becomes
-     * available.
      */
-    public function reserve(?int $timeout = null): ?Job;
+    public function reserve(): ?Job;
 
     /**
-     * Reserves/locks a ready job from the specified tube.
-     *
-     * A non-null timeout uses the 'reserve-with-timeout' instead of 'reserve'.
+     * Reserves/locks a ready job in a watched tube, uses the 'reserve-with-timeout' instead of 'reserve'.
      *
      * A timeout value of 0 will cause the server to immediately return either a
      * response or TIMED_OUT.  A positive value of timeout will limit the amount of
      * time the client will block on the reserve request until a job becomes
      * available.
-     *
-     * Using this method is equivalent to calling watch(), ignore() then
-     * reserve(), with the added benefit that it will not execute uneccessary
-     * WATCH or IGNORE commands if the client is already watching the
-     * specified tube.
-     *
-     * @return object Job
      */
-    public function reserveFromTube(string $tube, ?int $timeout = null): Job;
+    public function reserveWithTimeout(int $timeout): ?Job;
 
     /**
      * Gives statistical information about the specified job if it exists.
-     *
-     * @param Job|int $job
-     *
-     * @return object
      */
     public function statsJob(JobIdInterface $job): ArrayResponse;
 
     /**
      * Gives statistical information about the specified tube if it exists.
-     *
-     * @param string $tube
-     *
-     * @return object
      */
     public function statsTube(string $tube): ArrayResponse;
 
     /**
      * Gives statistical information about the beanstalkd system as a whole.
-     *
-     * @return object
      */
     public function stats(): ArrayResponse;
 

--- a/src/Contract/PheanstalkInterface.php
+++ b/src/Contract/PheanstalkInterface.php
@@ -1,6 +1,9 @@
 <?php
 
-namespace Pheanstalk;
+namespace Pheanstalk\Contract;
+
+use Pheanstalk\Connection;
+use Pheanstalk\Job;
 
 interface PheanstalkInterface
 {

--- a/src/Contract/ResponseInterface.php
+++ b/src/Contract/ResponseInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pheanstalk;
+namespace Pheanstalk\Contract;
 
 /**
  * A response from the beanstalkd server.
@@ -9,7 +9,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-interface Response
+interface ResponseInterface
 {
     // global error responses
     const RESPONSE_OUT_OF_MEMORY = 'OUT_OF_MEMORY';

--- a/src/Contract/ResponseParserInterface.php
+++ b/src/Contract/ResponseParserInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pheanstalk;
+namespace Pheanstalk\Contract;
 
 /**
  * A parser for response data sent from the beanstalkd server.
@@ -9,7 +9,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-interface ResponseParser
+interface ResponseParserInterface
 {
     /**
      * Parses raw response data into a Response object.

--- a/src/Contract/SocketInterface.php
+++ b/src/Contract/SocketInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pheanstalk;
+namespace Pheanstalk\Contract;
 
 /**
  * A mockable wrapper around PHP "socket" or "file pointer" access.
@@ -11,7 +11,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-interface Socket
+interface SocketInterface
 {
     /**
      * Writes data to the socket.

--- a/src/Contract/YamlResponseParserInterface.php
+++ b/src/Contract/YamlResponseParserInterface.php
@@ -1,6 +1,9 @@
 <?php
 
-namespace Pheanstalk;
+namespace Pheanstalk\Contract;
+
+use Pheanstalk\Exception;
+use Pheanstalk\Response;
 
 /**
  * A response parser for commands that return a subset of YAML.
@@ -12,8 +15,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class YamlResponseParser
-    implements \Pheanstalk\ResponseParser
+class YamlResponseParserInterface implements ResponseParserInterface
 {
     const MODE_LIST = 'list';
     const MODE_DICT = 'dict';
@@ -33,7 +35,7 @@ class YamlResponseParser
      */
     public function parseResponse($responseLine, $responseData)
     {
-        if ($responseLine == Response::RESPONSE_NOT_FOUND) {
+        if ($responseLine == ResponseInterface::RESPONSE_NOT_FOUND) {
             throw new Exception\ServerException(sprintf(
                 'Server reported %s',
                 $responseLine

--- a/src/Exception/DeadlineSoonException.php
+++ b/src/Exception/DeadlineSoonException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Pheanstalk\Exception;
+
+
+class DeadlineSoonException extends ClientException
+{
+
+}

--- a/src/Job.php
+++ b/src/Job.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use Pheanstalk\Contract\JobIdInterface;
+
 /**
  * A job in a beanstalkd server.
  *
@@ -9,7 +11,7 @@ namespace Pheanstalk;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class Job
+class Job implements JobIdInterface
 {
     const STATUS_READY = 'ready';
     const STATUS_RESERVED = 'reserved';
@@ -17,16 +19,16 @@ class Job
     const STATUS_BURIED = 'buried';
 
     private $_id;
-    private $_data;
+    private $data;
 
     /**
      * @param int    $id   The job ID
      * @param string $data The job data
      */
-    public function __construct($id, $data)
+    public function __construct(int $id, string $data)
     {
-        $this->_id = (int) $id;
-        $this->_data = $data;
+        $this->_id = $id;
+        $this->data = $data;
     }
 
     /**
@@ -34,7 +36,7 @@ class Job
      *
      * @return int
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->_id;
     }
@@ -44,8 +46,8 @@ class Job
      *
      * @return string
      */
-    public function getData()
+    public function getData(): string
     {
-        return $this->_data;
+        return $this->data;
     }
 }

--- a/src/JobId.php
+++ b/src/JobId.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace Pheanstalk;
+
+
+use Pheanstalk\Contract\JobIdInterface;
+
+class JobId implements JobIdInterface
+{
+    private $id;
+
+    public function __construct(int $id)
+    {
+        if ($id < 0) {
+            throw new \InvalidArgumentException('Id must be >= 0');
+        }
+        $this->id = $id;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}

--- a/src/Pheanstalk.php
+++ b/src/Pheanstalk.php
@@ -2,6 +2,10 @@
 
 namespace Pheanstalk;
 
+use Pheanstalk\Contract\CommandInterface;
+use Pheanstalk\Contract\PheanstalkInterface;
+use Pheanstalk\Contract\ResponseInterface;
+
 /**
  * Pheanstalk is a PHP client for the beanstalkd workqueue.
  *
@@ -279,8 +283,8 @@ class Pheanstalk implements PheanstalkInterface
         );
 
         $falseResponses = array(
-            Response::RESPONSE_DEADLINE_SOON,
-            Response::RESPONSE_TIMED_OUT,
+            ResponseInterface::RESPONSE_DEADLINE_SOON,
+            ResponseInterface::RESPONSE_TIMED_OUT,
         );
 
         if (in_array($response->getResponseName(), $falseResponses)) {
@@ -383,9 +387,9 @@ class Pheanstalk implements PheanstalkInterface
      * If a SocketException occurs, the connection is reset, and the command is
      * re-attempted once.
      *
-     * @param Command $command
+     * @param CommandInterface $command
      *
-     * @return Response
+     * @return ResponseInterface
      */
     private function _dispatch($command)
     {

--- a/src/Response/ArrayResponse.php
+++ b/src/Response/ArrayResponse.php
@@ -21,7 +21,7 @@ class ArrayResponse
      * @param string $name
      * @param array  $data
      */
-    public function __construct($name, $data)
+    public function __construct(string $name, array $data)
     {
         $this->_name = $name;
         parent::__construct($data);

--- a/src/Response/ArrayResponse.php
+++ b/src/Response/ArrayResponse.php
@@ -2,7 +2,7 @@
 
 namespace Pheanstalk\Response;
 
-use Pheanstalk\Response;
+use Pheanstalk\Contract\ResponseInterface;
 
 /**
  * A response with an ArrayObject interface to key => value data.
@@ -13,7 +13,7 @@ use Pheanstalk\Response;
  */
 class ArrayResponse
     extends \ArrayObject
-    implements Response
+    implements ResponseInterface
 {
     private $_name;
 

--- a/src/Socket/NativeSocket.php
+++ b/src/Socket/NativeSocket.php
@@ -2,8 +2,8 @@
 
 namespace Pheanstalk\Socket;
 
+use Pheanstalk\Contract\SocketInterface;
 use Pheanstalk\Exception;
-use Pheanstalk\Socket;
 
 /**
  * A Socket implementation around a fsockopen() stream.
@@ -12,7 +12,7 @@ use Pheanstalk\Socket;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class NativeSocket implements Socket
+class NativeSocket implements SocketInterface
 {
     /**
      * The default timeout for a blocking read on the socket.

--- a/src/Socket/NativeSocket.php
+++ b/src/Socket/NativeSocket.php
@@ -110,7 +110,7 @@ class NativeSocket implements SocketInterface
             if ($this->_wrapper()->feof($this->_socket)) {
                 throw new Exception\SocketException('Socket closed by server!');
             }
-            if (microtime(true) - $timer > $timeout) {
+            if (($data === false) && microtime(true) - $timer > $timeout) {
                 $this->disconnect();
                 throw new Exception\SocketException('Socket timed out!');
             }

--- a/src/YamlResponseParser.php
+++ b/src/YamlResponseParser.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Pheanstalk\Contract;
+namespace Pheanstalk;
 
-use Pheanstalk\Exception;
+use Pheanstalk\Contract\ResponseInterface;
+use Pheanstalk\Contract\ResponseParserInterface;
 use Pheanstalk\Response;
 
 /**
@@ -15,7 +16,7 @@ use Pheanstalk\Response;
  * @package Pheanstalk
  * @license http://www.opensource.org/licenses/mit-license.php
  */
-class YamlResponseParserInterface implements ResponseParserInterface
+class YamlResponseParser implements ResponseParserInterface
 {
     const MODE_LIST = 'list';
     const MODE_DICT = 'dict';

--- a/tests/Pheanstalk/BugfixTest.php
+++ b/tests/Pheanstalk/BugfixTest.php
@@ -2,6 +2,7 @@
 
 namespace Pheanstalk;
 
+use Pheanstalk\Contract\ResponseInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,7 +32,7 @@ class BugfixTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK '.strlen($data), $data),
-            Response::RESPONSE_OK,
+            ResponseInterface::RESPONSE_OK,
             array('pid' => '123', 'version' => '', 'key' => 'value')
         );
     }
@@ -40,7 +41,7 @@ class BugfixTest extends TestCase
     // private
 
     /**
-     * @param Response $response
+     * @param ResponseInterface $response
      * @param string   $expectName
      * @param array    $data
      */

--- a/tests/Pheanstalk/CommandTest.php
+++ b/tests/Pheanstalk/CommandTest.php
@@ -192,7 +192,7 @@ class CommandTest extends TestCase
 
     public function testPeek()
     {
-        $command = new Command\PeekCommand(5);
+        $command = new Command\PeekJobCommand(new JobId(5));
         $this->_assertCommandLine($command, 'peek 5');
 
         $this->_assertResponse(

--- a/tests/Pheanstalk/CommandTest.php
+++ b/tests/Pheanstalk/CommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Pheanstalk;
 
+use Pheanstalk\Contract\ResponseInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,7 +21,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('BURIED', null),
-            Response::RESPONSE_BURIED
+            ResponseInterface::RESPONSE_BURIED
         );
     }
 
@@ -31,7 +32,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('DELETED', null),
-            Response::RESPONSE_DELETED
+            ResponseInterface::RESPONSE_DELETED
         );
     }
 
@@ -42,7 +43,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('WATCHING 2', null),
-            Response::RESPONSE_WATCHING,
+            ResponseInterface::RESPONSE_WATCHING,
             array('count' => 2)
         );
     }
@@ -54,7 +55,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('KICKED 2', null),
-            Response::RESPONSE_KICKED,
+            ResponseInterface::RESPONSE_KICKED,
             array('kicked' => 2)
         );
     }
@@ -66,7 +67,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('KICKED', null),
-            Response::RESPONSE_KICKED
+            ResponseInterface::RESPONSE_KICKED
         );
     }
 
@@ -77,7 +78,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK 16', "---\n- one\n- two\n"),
-            Response::RESPONSE_OK,
+            ResponseInterface::RESPONSE_OK,
             array('one', 'two')
         );
     }
@@ -89,7 +90,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('USING default', null),
-            Response::RESPONSE_USING,
+            ResponseInterface::RESPONSE_USING,
             array('tube' => 'default')
         );
     }
@@ -102,7 +103,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('INSERTED 4', null),
-            Response::RESPONSE_INSERTED,
+            ResponseInterface::RESPONSE_INSERTED,
             array('id' => '4')
         );
     }
@@ -115,7 +116,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('RELEASED', null),
-            Response::RESPONSE_RELEASED
+            ResponseInterface::RESPONSE_RELEASED
         );
     }
 
@@ -126,7 +127,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('RESERVED 5 9', 'test data'),
-            Response::RESPONSE_RESERVED,
+            ResponseInterface::RESPONSE_RESERVED,
             array('id' => 5, 'jobdata' => 'test data')
         );
     }
@@ -138,7 +139,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('USING tube5', null),
-            Response::RESPONSE_USING,
+            ResponseInterface::RESPONSE_USING,
             array('tube' => 'tube5')
         );
     }
@@ -150,7 +151,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('WATCHING 3', null),
-            Response::RESPONSE_WATCHING,
+            ResponseInterface::RESPONSE_WATCHING,
             array('count' => '3')
         );
     }
@@ -162,7 +163,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('TIMED_OUT', null),
-            Response::RESPONSE_TIMED_OUT
+            ResponseInterface::RESPONSE_TIMED_OUT
         );
     }
 
@@ -173,7 +174,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('TOUCHED', null),
-            Response::RESPONSE_TOUCHED
+            ResponseInterface::RESPONSE_TOUCHED
         );
     }
 
@@ -184,7 +185,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK 16', "---\n- one\n- two\n"),
-            Response::RESPONSE_OK,
+            ResponseInterface::RESPONSE_OK,
             array('one', 'two')
         );
     }
@@ -196,7 +197,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('FOUND 5 9', 'test data'),
-            Response::RESPONSE_FOUND,
+            ResponseInterface::RESPONSE_FOUND,
             array('id' => 5, 'jobdata' => 'test data')
         );
     }
@@ -228,7 +229,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK '.strlen($data), $data),
-            Response::RESPONSE_OK,
+            ResponseInterface::RESPONSE_OK,
             array('id' => '8', 'tube' => 'test', 'state' => 'delayed')
         );
     }
@@ -242,7 +243,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK '.strlen($data), $data),
-            Response::RESPONSE_OK,
+            ResponseInterface::RESPONSE_OK,
             array('name' => 'test', 'current-jobs-ready' => '5')
         );
     }
@@ -256,7 +257,7 @@ class CommandTest extends TestCase
 
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('OK '.strlen($data), $data),
-            Response::RESPONSE_OK,
+            ResponseInterface::RESPONSE_OK,
             array('pid' => '123', 'version' => '1.3')
         );
     }
@@ -267,7 +268,7 @@ class CommandTest extends TestCase
         $this->_assertCommandLine($command, 'pause-tube testtube7 10');
         $this->_assertResponse(
             $command->getResponseParser()->parseResponse('PAUSED', null),
-            Response::RESPONSE_PAUSED
+            ResponseInterface::RESPONSE_PAUSED
         );
     }
 
@@ -290,7 +291,7 @@ class CommandTest extends TestCase
     }
 
     /**
-     * @param Response $response
+     * @param ResponseInterface $response
      * @param string   $expectName
      * @param array    $data
      */

--- a/tests/Pheanstalk/CommandTest.php
+++ b/tests/Pheanstalk/CommandTest.php
@@ -158,7 +158,7 @@ class CommandTest extends TestCase
 
     public function testReserveWithTimeout()
     {
-        $command = new Command\ReserveCommand(10);
+        $command = new Command\ReserveWithTimeoutCommand(10);
         $this->_assertCommandLine($command, 'reserve-with-timeout 10');
 
         $this->_assertResponse(
@@ -169,7 +169,7 @@ class CommandTest extends TestCase
 
     public function testTouch()
     {
-        $command = new Command\TouchCommand($this->_mockJob(5));
+        $command = new Command\TouchCommand(new JobId(5));
         $this->_assertCommandLine($command, 'touch 5');
 
         $this->_assertResponse(

--- a/tests/Pheanstalk/ConnectionTest.php
+++ b/tests/Pheanstalk/ConnectionTest.php
@@ -40,7 +40,7 @@ class ConnectionTest extends TestCase
         $command = new Command\UseCommand('test');
         $response = $connection->dispatchCommand($command);
 
-        $this->assertInstanceOf('\Pheanstalk\Response', $response);
+        $this->assertInstanceOf(Contract\ResponseInterface::class, $response);
     }
 
     public function testPersistentConnection()
@@ -58,7 +58,7 @@ class ConnectionTest extends TestCase
         $command = new Command\UseCommand('test');
         $response = $connection->dispatchCommand($command);
 
-        $this->assertInstanceOf('\Pheanstalk\Response', $response);
+        $this->assertInstanceOf(Contract\ResponseInterface::class, $response);
     }
 
     public function testConnectionResetIfSocketExceptionIsThrown()

--- a/tests/Pheanstalk/ExceptionsTest.php
+++ b/tests/Pheanstalk/ExceptionsTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use Pheanstalk\Exception\ClientException;
+use Pheanstalk\Exception\ServerException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,60 +18,60 @@ class ExceptionsTest extends TestCase
     public function testPheanstalkException()
     {
         $e = new Exception();
-        $this->assertInstanceOf('\Pheanstalk\Exception', $e);
+        $this->assertInstanceOf(Exception::class, $e);
     }
 
     public function testClientException()
     {
-        $e = new Exception\ClientException();
-        $this->assertInstanceOf('\Pheanstalk\Exception', $e);
+        $e = new ClientException();
+        $this->assertInstanceOf(Exception::class, $e);
     }
 
     public function testConnectionException()
     {
         $e = new Exception\ConnectionException(10, 'test');
-        $this->assertInstanceOf('\Pheanstalk\Exception\ClientException', $e);
+        $this->assertInstanceOf(ClientException::class, $e);
     }
 
     public function testCommandException()
     {
         $e = new Exception\CommandException('test');
-        $this->assertInstanceOf('\Pheanstalk\Exception\ClientException', $e);
+        $this->assertInstanceOf(ClientException::class, $e);
     }
 
     public function testServerException()
     {
         $e = new Exception\ServerException();
-        $this->assertInstanceOf('\Pheanstalk\Exception', $e);
+        $this->assertInstanceOf(Exception::class, $e);
     }
 
     public function testServerBadFormatException()
     {
         $e = new Exception\ServerBadFormatException();
-        $this->assertInstanceOf('\Pheanstalk\Exception\ServerException', $e);
+        $this->assertInstanceOf(ServerException::class, $e);
     }
 
     public function testServerDrainingException()
     {
         $e = new Exception\ServerDrainingException();
-        $this->assertInstanceOf('\Pheanstalk\Exception\ServerException', $e);
+        $this->assertInstanceOf(ServerException::class, $e);
     }
 
     public function testServerInternalErrorException()
     {
         $e = new Exception\ServerInternalErrorException();
-        $this->assertInstanceOf('\Pheanstalk\Exception\ServerException', $e);
+        $this->assertInstanceOf(ServerException::class, $e);
     }
 
     public function testServerOutOfMemoryException()
     {
         $e = new Exception\ServerOutOfMemoryException();
-        $this->assertInstanceOf('\Pheanstalk\Exception\ServerException', $e);
+        $this->assertInstanceOf(ServerException::class, $e);
     }
 
     public function testServerUnknownCommandException()
     {
         $e = new Exception\ServerUnknownCommandException();
-        $this->assertInstanceOf('\Pheanstalk\Exception\ServerException', $e);
+        $this->assertInstanceOf(ServerException::class, $e);
     }
 }

--- a/tests/Pheanstalk/FacadeConnectionTest.php
+++ b/tests/Pheanstalk/FacadeConnectionTest.php
@@ -76,7 +76,9 @@ class FacadeConnectionTest extends TestCase
         $putJob = $pheanstalk->putInTube('test', __METHOD__);
 
         // reserve a job from an unwatched tube - can't assume it is the one just added
-        $job = $pheanstalk->reserveFromTube('test');
+        $job = $pheanstalk->withWatchedTube('test', function(Pheanstalk $ph) {
+            return $ph->reserve();
+        });
 
         // delete the reserved job
         $pheanstalk->delete($job);
@@ -342,14 +344,14 @@ class FacadeConnectionTest extends TestCase
         // pause, expect no job from that queue
         $response = $pheanstalk
             ->pauseTube($tube, 60)
-            ->reserve(0);
+            ->reserveWithTimeout(0);
 
         $this->assertNull($response);
 
         // resume, expect job
         $response = $pheanstalk
             ->resumeTube($tube)
-            ->reserve(0);
+            ->reserveWithTimeout(0);
 
         $this->assertSame($response->getData(), __METHOD__);
     }

--- a/tests/Pheanstalk/FacadeConnectionTest.php
+++ b/tests/Pheanstalk/FacadeConnectionTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use Pheanstalk\Contract\PheanstalkInterface;
+use Pheanstalk\Job;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -69,7 +71,7 @@ class FacadeConnectionTest extends TestCase
         // reserve a job - can't assume it is the one just added
         $job = $pheanstalk->reserve();
 
-        $this->assertInstanceOf('\Pheanstalk\Job', $job);
+        $this->assertInstanceOf(Job::class, $job);
 
         // delete the reserved job
         $pheanstalk->delete($job);
@@ -82,7 +84,7 @@ class FacadeConnectionTest extends TestCase
         // reserve a job from an unwatched tube - can't assume it is the one just added
         $job = $pheanstalk->reserveFromTube('test');
 
-        $this->assertInstanceOf('\Pheanstalk\Job', $job);
+        $this->assertInstanceOf(Job::class, $job);
 
         // delete the reserved job
         $pheanstalk->delete($job);
@@ -108,7 +110,7 @@ class FacadeConnectionTest extends TestCase
         // reserve a job - can't assume it is the one just added
         $job = $pheanstalk->reserve();
 
-        $this->assertInstanceOf('\Pheanstalk\Job', $job);
+        $this->assertInstanceOf(Job::class, $job);
 
         // bury the reserved job
         $pheanstalk->bury($job);
@@ -369,7 +371,7 @@ class FacadeConnectionTest extends TestCase
     {
         $facade = $this->_getFacade();
 
-        $connection = $this->getMockBuilder('\Pheanstalk\Connection')
+        $connection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -381,7 +383,7 @@ class FacadeConnectionTest extends TestCase
     {
         $facade = $this->_getFacade();
 
-        $this->assertInstanceOf('\Pheanstalk\PheanstalkInterface', $facade);
+        $this->assertInstanceOf(PheanstalkInterface::class, $facade);
     }
 
     // ----------------------------------------

--- a/tests/Pheanstalk/ResponseParserExceptionTest.php
+++ b/tests/Pheanstalk/ResponseParserExceptionTest.php
@@ -2,6 +2,8 @@
 
 namespace Pheanstalk;
 
+use Pheanstalk\Contract\CommandInterface;
+use Pheanstalk\Contract\YamlResponseParserInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -80,7 +82,7 @@ class ResponseParserExceptionTest extends TestCase
     public function testYamlResponseParserNotFound()
     {
         $this->_expectServerExceptionForResponse(
-            new YamlResponseParser(YamlResponseParser::MODE_DICT),
+            new YamlResponseParserInterface(YamlResponseParserInterface::MODE_DICT),
             'NOT_FOUND'
         );
     }
@@ -119,7 +121,7 @@ class ResponseParserExceptionTest extends TestCase
     }
 
     /**
-     * @param Command
+     * @param CommandInterface
      * @param string the response line to parse.
      * @param string the type of exception to expect.
      */
@@ -130,7 +132,7 @@ class ResponseParserExceptionTest extends TestCase
     }
 
     /**
-     * @param Command
+     * @param CommandInterface
      * @param string the response line to parse.
      */
     private function _expectServerExceptionForResponse($command, $response)

--- a/tests/Pheanstalk/ResponseParserExceptionTest.php
+++ b/tests/Pheanstalk/ResponseParserExceptionTest.php
@@ -3,7 +3,6 @@
 namespace Pheanstalk;
 
 use Pheanstalk\Contract\CommandInterface;
-use Pheanstalk\Contract\YamlResponseParserInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -66,7 +65,7 @@ class ResponseParserExceptionTest extends TestCase
     public function testPeekNotFound()
     {
         $this->_expectServerExceptionForResponse(
-            new Command\PeekCommand(5),
+            new Command\PeekJobCommand(new JobId(5)),
             'NOT_FOUND'
         );
     }
@@ -82,7 +81,7 @@ class ResponseParserExceptionTest extends TestCase
     public function testYamlResponseParserNotFound()
     {
         $this->_expectServerExceptionForResponse(
-            new YamlResponseParserInterface(YamlResponseParserInterface::MODE_DICT),
+            new YamlResponseParser(YamlResponseParser::MODE_DICT),
             'NOT_FOUND'
         );
     }

--- a/tests/Pheanstalk/ServerErrorExceptionTest.php
+++ b/tests/Pheanstalk/ServerErrorExceptionTest.php
@@ -29,7 +29,7 @@ class ServerErrorExceptionTest extends TestCase
      */
     private function _connection($line)
     {
-        $socket = $this->getMockBuilder('\Pheanstalk\Socket')
+        $socket = $this->getMockBuilder('\Pheanstalk\Contract\SocketInterface')
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
- Implements #45 
- Updates interfaces to use strict types
- Non-configuration commands on `PheanstalkInterface` no longer return `$this`.
- Split `PeekCommand` to not use mixed argument types.
- Split reserve functions (#178)
- Functions that have side effects have been removed (`putInTube`), or have had their side effect removed (`peekReady` now doesn't allow tube switching). (#142)
- Added prototype of `withUsedTube()` and `withWatchedTube()` to base class.